### PR TITLE
Add Agent IDE Org site

### DIFF
--- a/agentide.org/about.html
+++ b/agentide.org/about.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>About - Agent IDE Org</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto+Slab:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <div class="container">
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="services.html">Services</a>
+      <a href="products.html">Products</a>
+      <a href="blog.html">Blog</a>
+      <a href="contact.html">Contact</a>
+      <button id="themeToggle" class="toggle">Toggle</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <section class="container">
+    <h1>About Agent IDE Org</h1>
+    <p>Agent IDE Org began as a collaboration between AI researchers and developers who wanted a simpler way to create autonomous agents. Our platform focuses on making advanced AI accessible to everyone.</p>
+    <p>From visual design tools to rich APIs, our mission is to help you bring intelligent automation to any project without heavy coding.</p>
+    <img src="https://placehold.co/600x300?text=Team" alt="Our team">
+  </section>
+</main>
+<footer>
+  <div class="container">
+    <p>&copy; <span id="year"></span> Agent IDE Org. All rights reserved.</p>
+  </div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/agentide.org/authority.html
+++ b/agentide.org/authority.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Authority - Agent IDE Org</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto+Slab:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <div class="container">
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="services.html">Services</a>
+      <a href="products.html">Products</a>
+      <a href="blog.html">Blog</a>
+      <a href="contact.html">Contact</a>
+      <button id="themeToggle" class="toggle">Toggle</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <section class="container">
+    <h1>Authority</h1>
+    <p>Content coming soon for Authority.</p>
+  </section>
+</main>
+<footer>
+  <div class="container">
+    <p>&copy; <span id="year"></span> Agent IDE Org. All rights reserved.</p>
+  </div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/agentide.org/blog-article-example.html
+++ b/agentide.org/blog-article-example.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blog Article - Agent IDE Org</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto+Slab:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <div class="container">
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="services.html">Services</a>
+      <a href="products.html">Products</a>
+      <a href="blog.html">Blog</a>
+      <a href="contact.html">Contact</a>
+      <button id="themeToggle" class="toggle">Toggle</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <section class="container">
+    <h1>Why Low-Code Tools Speed Up AI Development</h1>
+    <p>Building AI agents from scratch can be slow. Low-code platforms like Agent IDE Org allow teams to prototype quickly and iterate faster.</p>
+    <img src="https://placehold.co/600x300?text=Article" alt="Article graphic">
+  </section>
+</main>
+<footer>
+  <div class="container">
+    <p>&copy; <span id="year"></span> Agent IDE Org. All rights reserved.</p>
+  </div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/agentide.org/blog.html
+++ b/agentide.org/blog.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blog - Agent IDE Org</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto+Slab:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <div class="container">
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="services.html">Services</a>
+      <a href="products.html">Products</a>
+      <a href="blog.html">Blog</a>
+      <a href="contact.html">Contact</a>
+      <button id="themeToggle" class="toggle">Toggle</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <section class="container">
+    <h1>Blog</h1>
+    <p>Insights on building practical AI solutions. Read our latest articles below.</p>
+    <ul>
+      <li><a href="blog-article-example.html">Why Low-Code Tools Speed Up AI Development</a></li>
+    </ul>
+  </section>
+</main>
+<footer>
+  <div class="container">
+    <p>&copy; <span id="year"></span> Agent IDE Org. All rights reserved.</p>
+  </div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/agentide.org/contact.html
+++ b/agentide.org/contact.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Contact - Agent IDE Org</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto+Slab:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <div class="container">
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="services.html">Services</a>
+      <a href="products.html">Products</a>
+      <a href="blog.html">Blog</a>
+      <a href="contact.html">Contact</a>
+      <button id="themeToggle" class="toggle">Toggle</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <section class="container">
+    <h1>Contact Us</h1>
+    <p>Email us at info@agentide.org or complete the form below.</p>
+    <form>
+      <p><input type="text" placeholder="Name"></p>
+      <p><input type="email" placeholder="Email"></p>
+      <p><textarea placeholder="Message"></textarea></p>
+      <p><button type="submit" class="toggle">Send</button></p>
+    </form>
+    <img src="https://placehold.co/600x300?text=Office" alt="Office">
+  </section>
+</main>
+<footer>
+  <div class="container">
+    <p>&copy; <span id="year"></span> Agent IDE Org. All rights reserved.</p>
+  </div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/agentide.org/credibility.html
+++ b/agentide.org/credibility.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Credibility - Agent IDE Org</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto+Slab:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <div class="container">
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="services.html">Services</a>
+      <a href="products.html">Products</a>
+      <a href="blog.html">Blog</a>
+      <a href="contact.html">Contact</a>
+      <button id="themeToggle" class="toggle">Toggle</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <section class="container">
+    <h1>Credibility</h1>
+    <p>Content coming soon for Credibility.</p>
+  </section>
+</main>
+<footer>
+  <div class="container">
+    <p>&copy; <span id="year"></span> Agent IDE Org. All rights reserved.</p>
+  </div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/agentide.org/css/style.css
+++ b/agentide.org/css/style.css
@@ -1,0 +1,97 @@
+:root {
+  --primary-color: #5b3ddc;
+  --secondary-color: #ff914d;
+  --bg-light: #ffffff;
+  --bg-dark: #131419;
+  --text-light: #212529;
+  --text-dark: #e9ecef;
+  --font-body: 'Inter', sans-serif;
+  --font-head: 'Roboto Slab', serif;
+}
+
+body {
+  font-family: var(--font-body);
+  background-color: var(--bg-light);
+  color: var(--text-light);
+  margin: 0;
+  line-height: 1.6;
+}
+
+[data-theme='dark'] body {
+  background-color: var(--bg-dark);
+  color: var(--text-dark);
+}
+
+h1, h2, h3, h4, h5 {
+  font-family: var(--font-head);
+  margin-top: 0;
+}
+
+header, footer {
+  background: var(--primary-color);
+  color: #fff;
+  padding: 1rem 0;
+}
+
+nav a {
+  color: #fff;
+  margin: 0 0.5rem;
+  text-decoration: none;
+  font-weight: 500;
+}
+nav a:hover {
+  text-decoration: underline;
+}
+
+.container {
+  width: 90%;
+  max-width: 1100px;
+  margin: auto;
+}
+
+.hero {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  padding: 3rem 0;
+}
+.hero .text {
+  flex: 1 1 300px;
+}
+.hero img {
+  flex: 1 1 300px;
+  max-width: 100%;
+  border-radius: 8px;
+}
+
+section {
+  padding: 2rem 0;
+}
+
+.features {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+}
+.feature {
+  background: var(--bg-light);
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
+[data-theme='dark'] .feature {
+  background: #1d1f27;
+}
+
+footer p {
+  margin: 0;
+}
+
+.toggle {
+  cursor: pointer;
+  background: var(--secondary-color);
+  border: none;
+  padding: 0.4rem 0.8rem;
+  border-radius: 4px;
+  color: #fff;
+}

--- a/agentide.org/demo.html
+++ b/agentide.org/demo.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Demo Request - Agent IDE Org</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto+Slab:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <div class="container">
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="services.html">Services</a>
+      <a href="products.html">Products</a>
+      <a href="blog.html">Blog</a>
+      <a href="contact.html">Contact</a>
+      <button id="themeToggle" class="toggle">Toggle</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <section class="container">
+    <h1>Demo Request</h1>
+    <p>Content coming soon for Demo Request.</p>
+  </section>
+</main>
+<footer>
+  <div class="container">
+    <p>&copy; <span id="year"></span> Agent IDE Org. All rights reserved.</p>
+  </div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/agentide.org/disclosure.html
+++ b/agentide.org/disclosure.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Disclosure - Agent IDE Org</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto+Slab:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <div class="container">
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="services.html">Services</a>
+      <a href="products.html">Products</a>
+      <a href="blog.html">Blog</a>
+      <a href="contact.html">Contact</a>
+      <button id="themeToggle" class="toggle">Toggle</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <section class="container">
+    <h1>Disclosure</h1>
+    <p>Content coming soon for Disclosure.</p>
+  </section>
+</main>
+<footer>
+  <div class="container">
+    <p>&copy; <span id="year"></span> Agent IDE Org. All rights reserved.</p>
+  </div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/agentide.org/experience.html
+++ b/agentide.org/experience.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Experience - Agent IDE Org</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto+Slab:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <div class="container">
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="services.html">Services</a>
+      <a href="products.html">Products</a>
+      <a href="blog.html">Blog</a>
+      <a href="contact.html">Contact</a>
+      <button id="themeToggle" class="toggle">Toggle</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <section class="container">
+    <h1>Experience</h1>
+    <p>Content coming soon for Experience.</p>
+  </section>
+</main>
+<footer>
+  <div class="container">
+    <p>&copy; <span id="year"></span> Agent IDE Org. All rights reserved.</p>
+  </div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/agentide.org/expertise.html
+++ b/agentide.org/expertise.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Expertise - Agent IDE Org</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto+Slab:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <div class="container">
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="services.html">Services</a>
+      <a href="products.html">Products</a>
+      <a href="blog.html">Blog</a>
+      <a href="contact.html">Contact</a>
+      <button id="themeToggle" class="toggle">Toggle</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <section class="container">
+    <h1>Expertise</h1>
+    <p>Content coming soon for Expertise.</p>
+  </section>
+</main>
+<footer>
+  <div class="container">
+    <p>&copy; <span id="year"></span> Agent IDE Org. All rights reserved.</p>
+  </div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/agentide.org/faq.html
+++ b/agentide.org/faq.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>FAQ - Agent IDE Org</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto+Slab:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <div class="container">
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="services.html">Services</a>
+      <a href="products.html">Products</a>
+      <a href="blog.html">Blog</a>
+      <a href="contact.html">Contact</a>
+      <button id="themeToggle" class="toggle">Toggle</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <section class="container">
+    <h1>FAQ</h1>
+    <p>Content coming soon for FAQ.</p>
+  </section>
+</main>
+<footer>
+  <div class="container">
+    <p>&copy; <span id="year"></span> Agent IDE Org. All rights reserved.</p>
+  </div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/agentide.org/images_prompt.txt
+++ b/agentide.org/images_prompt.txt
@@ -1,0 +1,5 @@
+1. Logo for Agent IDE Org - a clean symbol representing AI agents and coding tools.
+2. Illustration of a dashboard showing AI workflow - used on homepage hero section.
+3. Icon-style images for features like visual builder, code integration, and analytics.
+4. Team member headshots for about page.
+5. Generic office background for contact page.

--- a/agentide.org/index.html
+++ b/agentide.org/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Agent IDE Org - Home</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto+Slab:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <div class="container">
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="services.html">Services</a>
+      <a href="products.html">Products</a>
+      <a href="blog.html">Blog</a>
+      <a href="contact.html">Contact</a>
+      <button id="themeToggle" class="toggle">Toggle</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <section class="hero">
+    <div class="container hero">
+      <div class="text">
+        <h1>The Integrated Development Environment for Next-Gen AI Agents</h1>
+        <p>Agent IDE Org lets you design, test and deploy AI agents using visual tools or code. Build smarter workflows without the heavy setup.</p>
+      </div>
+      <img src="https://placehold.co/600x400?text=Dashboard" alt="Dashboard preview">
+    </div>
+  </section>
+  <section>
+    <div class="container">
+      <h2>Key Features</h2>
+      <div class="features">
+        <div class="feature">
+          <h3>Visual Builder</h3>
+          <p>Drag and drop nodes to create logic flows for your agent.</p>
+        </div>
+        <div class="feature">
+          <h3>Code Integration</h3>
+          <p>Add Python or JavaScript when you need more control.</p>
+        </div>
+        <div class="feature">
+          <h3>Deployment Hub</h3>
+          <p>Launch your agent to web, mobile or chat apps in one click.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section>
+    <div class="container">
+      <h2>Get Started</h2>
+      <p>Join the community and start building your own AI assistants today.</p>
+      <a href="contact.html" class="toggle">Sign Up</a>
+    </div>
+  </section>
+</main>
+<footer>
+  <div class="container">
+    <p>&copy; <span id="year"></span> Agent IDE Org. All rights reserved.</p>
+  </div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/agentide.org/js/script.js
+++ b/agentide.org/js/script.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('themeToggle');
+  const htmlEl = document.documentElement;
+  const saved = localStorage.getItem('theme') || 'light';
+  htmlEl.setAttribute('data-theme', saved);
+  toggle.addEventListener('click', () => {
+    const cur = htmlEl.getAttribute('data-theme');
+    const next = cur === 'light' ? 'dark' : 'light';
+    htmlEl.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+  });
+
+  const yearSpan = document.getElementById('year');
+  if (yearSpan) yearSpan.textContent = new Date().getFullYear();
+});

--- a/agentide.org/privacy.html
+++ b/agentide.org/privacy.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy - Agent IDE Org</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto+Slab:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <div class="container">
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="services.html">Services</a>
+      <a href="products.html">Products</a>
+      <a href="blog.html">Blog</a>
+      <a href="contact.html">Contact</a>
+      <button id="themeToggle" class="toggle">Toggle</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <section class="container">
+    <h1>Privacy Policy</h1>
+    <p>Content coming soon for Privacy Policy.</p>
+  </section>
+</main>
+<footer>
+  <div class="container">
+    <p>&copy; <span id="year"></span> Agent IDE Org. All rights reserved.</p>
+  </div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/agentide.org/products.html
+++ b/agentide.org/products.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Products - Agent IDE Org</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto+Slab:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <div class="container">
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="services.html">Services</a>
+      <a href="products.html">Products</a>
+      <a href="blog.html">Blog</a>
+      <a href="contact.html">Contact</a>
+      <button id="themeToggle" class="toggle">Toggle</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <section class="container">
+    <h1>Platform Highlights</h1>
+    <p>Agent IDE Org is available in a free community tier and several paid plans. All versions include the core IDE and deployment hub, with advanced tiers unlocking team collaboration and marketplace features.</p>
+    <img src="https://placehold.co/600x300?text=Plans" alt="Plans">
+  </section>
+</main>
+<footer>
+  <div class="container">
+    <p>&copy; <span id="year"></span> Agent IDE Org. All rights reserved.</p>
+  </div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/agentide.org/pros-cons.html
+++ b/agentide.org/pros-cons.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pros and Cons - Agent IDE Org</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto+Slab:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <div class="container">
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="services.html">Services</a>
+      <a href="products.html">Products</a>
+      <a href="blog.html">Blog</a>
+      <a href="contact.html">Contact</a>
+      <button id="themeToggle" class="toggle">Toggle</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <section class="container">
+    <h1>Pros and Cons</h1>
+    <p>Content coming soon for Pros and Cons.</p>
+  </section>
+</main>
+<footer>
+  <div class="container">
+    <p>&copy; <span id="year"></span> Agent IDE Org. All rights reserved.</p>
+  </div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/agentide.org/reviews.html
+++ b/agentide.org/reviews.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reviews - Agent IDE Org</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto+Slab:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <div class="container">
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="services.html">Services</a>
+      <a href="products.html">Products</a>
+      <a href="blog.html">Blog</a>
+      <a href="contact.html">Contact</a>
+      <button id="themeToggle" class="toggle">Toggle</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <section class="container">
+    <h1>Reviews</h1>
+    <p>Content coming soon for Reviews.</p>
+  </section>
+</main>
+<footer>
+  <div class="container">
+    <p>&copy; <span id="year"></span> Agent IDE Org. All rights reserved.</p>
+  </div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/agentide.org/services.html
+++ b/agentide.org/services.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Services - Agent IDE Org</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto+Slab:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <div class="container">
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="services.html">Services</a>
+      <a href="products.html">Products</a>
+      <a href="blog.html">Blog</a>
+      <a href="contact.html">Contact</a>
+      <button id="themeToggle" class="toggle">Toggle</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <section class="container">
+    <h1>What We Offer</h1>
+    <p>Our platform includes everything from a drag-and-drop IDE to deployment pipelines and analytics. Whether you prefer no-code creation or full scripting, Agent IDE Org supports your workflow.</p>
+    <img src="https://placehold.co/600x300?text=Services" alt="Services illustration">
+  </section>
+</main>
+<footer>
+  <div class="container">
+    <p>&copy; <span id="year"></span> Agent IDE Org. All rights reserved.</p>
+  </div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/agentide.org/terms.html
+++ b/agentide.org/terms.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Terms of Use - Agent IDE Org</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto+Slab:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <div class="container">
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="services.html">Services</a>
+      <a href="products.html">Products</a>
+      <a href="blog.html">Blog</a>
+      <a href="contact.html">Contact</a>
+      <button id="themeToggle" class="toggle">Toggle</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <section class="container">
+    <h1>Terms of Use</h1>
+    <p>Content coming soon for Terms of Use.</p>
+  </section>
+</main>
+<footer>
+  <div class="container">
+    <p>&copy; <span id="year"></span> Agent IDE Org. All rights reserved.</p>
+  </div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/agentide.org/trustworthy.html
+++ b/agentide.org/trustworthy.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Trustworthiness - Agent IDE Org</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto+Slab:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<header>
+  <div class="container">
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="services.html">Services</a>
+      <a href="products.html">Products</a>
+      <a href="blog.html">Blog</a>
+      <a href="contact.html">Contact</a>
+      <button id="themeToggle" class="toggle">Toggle</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <section class="container">
+    <h1>Trustworthiness</h1>
+    <p>Content coming soon for Trustworthiness.</p>
+  </section>
+</main>
+<footer>
+  <div class="container">
+    <p>&copy; <span id="year"></span> Agent IDE Org. All rights reserved.</p>
+  </div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new static website for agentide.org
- include placeholder images and description file
- implement simple light/dark theme with Inter and Roboto Slab fonts
- provide pages for about, services, products, blog and more

## Testing
- `git status --short`
