### PR TITLE
Add Agent Messengers static marketing site

### DIFF
--- a/agentmessengers.com/about.html
+++ b/agentmessengers.com/about.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>About Agent Messengers | Our Mission &amp; Team</title>
+  <meta name="description" content="Learn how Agent Messengers empowers regulated insurance and advisory organizations with AI-assisted communications and meet the leadership team behind the platform.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700&family=Montserrat:wght@600;700;800&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuU8Q0Kw5y7FZ5Fk5clU61M0W6Nqd53Y2xZC2Y1Qd5kZw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">
+        Agent Messengers
+        <span>AI-managed outreach for regulated teams</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="mainNav">
+        <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
+          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+          <li class="nav-item"><a class="nav-link active" href="about.html">About</a></li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="services.html" id="servicesDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Services</a>
+            <ul class="dropdown-menu" aria-labelledby="servicesDropdown">
+              <li><a class="dropdown-item" href="services.html#essentials">Essentials Suite</a></li>
+              <li><a class="dropdown-item" href="services.html#compliance">Compliance Plus</a></li>
+              <li><a class="dropdown-item" href="services.html#enterprise">Global Enterprise</a></li>
+            </ul>
+          </li>
+          <li class="nav-item"><a class="nav-link" href="blog.html">Blog</a></li>
+          <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
+          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+          <li class="nav-item"><a class="btn btn-link login-link" href="https://agentmessengers.com/login">Login</a></li>
+          <li class="nav-item"><a class="btn btn-primary" href="demo.html">Request a Demo</a></li>
+        </ul>
+        <div class="theme-toggle">
+          <i class="fa-regular fa-sun"></i>
+          <div class="form-check form-switch m-0">
+            <input class="form-check-input" type="checkbox" role="switch" id="themeSwitch" aria-label="Toggle dark mode">
+          </div>
+          <i class="fa-regular fa-moon"></i>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main>
+    <section class="article-hero">
+      <div class="container">
+        <div class="row align-items-center gy-4">
+          <div class="col-lg-7 text-white">
+            <h1 class="text-white">Our mission is to make compliant communications effortless</h1>
+            <p class="lead text-white-50">We bridge the gap between regulatory rigor and human connection so every policyholder feels seen, heard, and protected.</p>
+          </div>
+          <div class="col-lg-5 text-lg-end text-white">
+            <div class="stat-chip bg-white text-dark d-inline-flex"><i class="fa-solid fa-flag-checkered text-primary"></i> Founded in 2021</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="article-content">
+      <div class="container">
+        <div class="row gy-5">
+          <div class="col-lg-6">
+            <h2>Our Mission</h2>
+            <p>Agent Messengers enables regulated insurance and advisory teams to orchestrate timely, transparent conversations with the people who rely on them. By combining AI-generated insights with compliance-first workflows, we help agencies deliver empathy at scale while maintaining the trust of regulators and clients alike.</p>
+          </div>
+          <div class="col-lg-6">
+            <h2>Our Story</h2>
+            <p>Our founding team spent a decade managing communication crisis desks for national insurers. We saw first-hand how impossible it was to keep every agent aligned across channels, states, and evolving regulations. In 2021 we launched Agent Messengers to convert static policy memos into dynamic briefings that agents can deploy confidently within hours.</p>
+            <p>Today we partner with forward-thinking carriers, MGAs, and wealth firms across North America, powering millions of compliant client touchpoints every quarter.</p>
+          </div>
+        </div>
+
+        <div class="row gy-4 mt-4">
+          <div class="col-12">
+            <h2>Meet the Team</h2>
+          </div>
+          <div class="col-md-4">
+            <div class="plan-card text-center p-4 h-100">
+              <img src="images/team-ava.svg" alt="Portrait of Ava Chen" class="mb-3" width="120" height="120">
+              <h3 class="h4">Ava Chen</h3>
+              <p class="text-muted-custom mb-2">Co-founder &amp; CEO</p>
+              <p>Ava built compliance automation programs for Fortune 100 insurers before founding Agent Messengers. She is a former actuary turned product strategist who ensures our AI stays accountable.</p>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="plan-card text-center p-4 h-100">
+              <img src="images/team-malik.svg" alt="Portrait of Malik Rhodes" class="mb-3" width="120" height="120">
+              <h3 class="h4">Malik Rhodes</h3>
+              <p class="text-muted-custom mb-2">Chief Compliance Officer</p>
+              <p>Malik previously led market conduct examinations across 23 states. He designs our rule libraries, supervises human review workflows, and coaches clients on regulator collaboration.</p>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="plan-card text-center p-4 h-100">
+              <img src="images/team-sofia.svg" alt="Portrait of Sofia Patel" class="mb-3" width="120" height="120">
+              <h3 class="h4">Sofia Patel</h3>
+              <p class="text-muted-custom mb-2">Head of Applied AI</p>
+              <p>Sofia leads our research labs, fusing multilingual natural language processing with ethical guardrails. She brings experience from fintech fraud prevention and humanitarian NLP projects.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="row gy-4 mt-5">
+          <div class="col-12">
+            <h2>Our Values</h2>
+          </div>
+          <div class="col-md-6 col-lg-3">
+            <div class="feature-card h-100">
+              <div class="icon-circle"><i class="fa-solid fa-scale-balanced"></i></div>
+              <h3>Integrity first</h3>
+              <p>We design systems that reinforce ethical decision-making and transparent auditability in every release.</p>
+            </div>
+          </div>
+          <div class="col-md-6 col-lg-3">
+            <div class="feature-card h-100">
+              <div class="icon-circle"><i class="fa-solid fa-hands-holding-circle"></i></div>
+              <h3>Empathy at scale</h3>
+              <p>We center the families, advisors, and agents impacted by every message, ensuring content feels personal and clear.</p>
+            </div>
+          </div>
+          <div class="col-md-6 col-lg-3">
+            <div class="feature-card h-100">
+              <div class="icon-circle"><i class="fa-solid fa-wand-magic-sparkles"></i></div>
+              <h3>Human + AI synergy</h3>
+              <p>Automation should amplify, not replace, the expertise of licensed professionals and compliance reviewers.</p>
+            </div>
+          </div>
+          <div class="col-md-6 col-lg-3">
+            <div class="feature-card h-100">
+              <div class="icon-circle"><i class="fa-solid fa-globe-americas"></i></div>
+              <h3>Global stewardship</h3>
+              <p>We champion inclusive language, accessibility, and localization that respects the communities our clients serve.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="row gy-4">
+        <div class="col-md-4">
+          <div class="footer-brand">Agent Messengers</div>
+          <p class="footer-tagline">Empowering regulated teams to deliver compliant conversations at scale.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="d-inline-flex align-items-center gap-2">
+            Powered by <span class="fw-semibold">Netshow.AI</span>
+            <i class="fa-solid fa-arrow-up-right-from-square"></i>
+          </a>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Quick Links</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About Us</a></li>
+            <li><a href="services.html">Services</a></li>
+            <li><a href="products.html">Products</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Resources</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="blog.html">Blog</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="reviews.html">Reviews</a></li>
+            <li><a href="demo.html">Demo</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Legal</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="privacy.html">Privacy Policy</a></li>
+            <li><a href="terms.html">Terms of Use</a></li>
+            <li><a href="disclosure.html">Disclosure</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Contact</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="tel:+18885551234">+1 (888) 555-1234</a></li>
+            <li><a href="mailto:hello@agentmessengers.com">hello@agentmessengers.com</a></li>
+            <li>1355 Market Street, Suite 420<br>San Francisco, CA 94103</li>
+          </ul>
+          <div class="footer-social mt-3">
+            <a href="https://www.facebook.com" aria-label="Facebook"><i class="fa-brands fa-facebook-f"></i></a>
+            <a href="https://www.twitter.com" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+            <a href="https://www.instagram.com" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+            <a href="https://www.linkedin.com" aria-label="LinkedIn"><i class="fa-brands fa-linkedin-in"></i></a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom text-center text-md-start mt-4">
+        © 2025 Agent Messengers. All Rights Reserved.
+      </div>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+  <script src="js/script.js"></script>
+</body>
+</html>

--- a/agentmessengers.com/blog-article-1.html
+++ b/agentmessengers.com/blog-article-1.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>5 Localization Wins from Insurance Leaders | Agent Messengers</title>
+  <meta name="description" content="Insurance communication leaders share localization strategies that improve regulatory compliance and customer trust.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700&family=Montserrat:wght@600;700;800&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuU8Q0Kw5y7FZ5Fk5clU61M0W6Nqd53Y2xZC2Y1Qd5kZw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">
+        Agent Messengers
+        <span>AI-managed outreach for regulated teams</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="mainNav">
+        <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
+          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="services.html" id="servicesDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Services</a>
+            <ul class="dropdown-menu" aria-labelledby="servicesDropdown">
+              <li><a class="dropdown-item" href="services.html#essentials">Essentials Suite</a></li>
+              <li><a class="dropdown-item" href="services.html#compliance">Compliance Plus</a></li>
+              <li><a class="dropdown-item" href="services.html#enterprise">Global Enterprise</a></li>
+            </ul>
+          </li>
+          <li class="nav-item"><a class="nav-link active" href="blog.html">Blog</a></li>
+          <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
+          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+          <li class="nav-item"><a class="btn btn-link login-link" href="https://agentmessengers.com/login">Login</a></li>
+          <li class="nav-item"><a class="btn btn-primary" href="demo.html">Request a Demo</a></li>
+        </ul>
+        <div class="theme-toggle">
+          <i class="fa-regular fa-sun"></i>
+          <div class="form-check form-switch m-0">
+            <input class="form-check-input" type="checkbox" role="switch" id="themeSwitch" aria-label="Toggle dark mode">
+          </div>
+          <i class="fa-regular fa-moon"></i>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main>
+    <section class="article-hero">
+      <div class="container text-white">
+        <h1 class="text-white">5 Localization Wins from Insurance Leaders</h1>
+        <p class="lead text-white-50">Localization is no longer a translation project—it is a compliance imperative. Here are the tactics leading carriers rely on.</p>
+      </div>
+    </section>
+
+    <section class="article-content">
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="col-lg-9">
+            <p>Regulators increasingly expect carriers to communicate with policyholders in their preferred language. Organizations that treat localization as a strategic capability are experiencing higher renewal rates and fewer remediation costs.</p>
+
+            <h2>1. Build bilingual review pods</h2>
+            <p>Leading insurers pair AI-generated drafts with bilingual reviewers who understand both compliance and cultural nuance. These pods work inside Agent Messengers to approve scripts in hours instead of days.</p>
+
+            <h2>2. Align disclosures with state expectations</h2>
+            <p>Localization is not just about words—it is about meeting jurisdiction-specific disclosure mandates. Teams map each translated asset to state bulletins using our Regulatory Intelligence module to prevent rework.</p>
+
+            <h2>3. Embrace voice and video</h2>
+            <p>Carriers are recording short explainer videos in multiple languages and distributing them via secure portals. Agents rely on the synchronized transcripts generated by Agent Messengers to ensure accuracy across channels.</p>
+
+            <h2>4. Track sentiment and comprehension</h2>
+            <p>Feedback surveys are embedded into every localized campaign. Data flows back into dashboards that reveal which messages resonate and which require additional clarity or coaching.</p>
+
+            <h2>5. Share the wins internally</h2>
+            <p>Localization success stories are showcased in internal newsletters and learning modules. Highlighting agent impact encourages adoption and demonstrates how compliance and growth work hand in hand.</p>
+
+            <blockquote>“We saw a 17% lift in cross-sell conversions after investing in localized video briefings. Agent Messengers helped us operationalize the workflow without adding headcount,” notes Meridian Mutual’s distribution chief.</blockquote>
+
+            <p>Localization will continue to evolve as regulators and customers raise expectations. By pairing AI assistance with the right governance, insurers can deliver clarity, empathy, and compliance across every language.</p>
+
+            <div class="d-flex flex-wrap gap-3 mt-4">
+              <a href="blog.html" class="btn btn-primary">Back to insights</a>
+              <a href="demo.html" class="btn btn-secondary-custom">See localization demo</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="row gy-4">
+        <div class="col-md-4">
+          <div class="footer-brand">Agent Messengers</div>
+          <p class="footer-tagline">Empowering regulated teams to deliver compliant conversations at scale.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="d-inline-flex align-items-center gap-2">
+            Powered by <span class="fw-semibold">Netshow.AI</span>
+            <i class="fa-solid fa-arrow-up-right-from-square"></i>
+          </a>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Quick Links</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About Us</a></li>
+            <li><a href="services.html">Services</a></li>
+            <li><a href="products.html">Products</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Resources</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="blog.html">Blog</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="reviews.html">Reviews</a></li>
+            <li><a href="demo.html">Demo</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Legal</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="privacy.html">Privacy Policy</a></li>
+            <li><a href="terms.html">Terms of Use</a></li>
+            <li><a href="disclosure.html">Disclosure</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Contact</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="tel:+18885551234">+1 (888) 555-1234</a></li>
+            <li><a href="mailto:hello@agentmessengers.com">hello@agentmessengers.com</a></li>
+            <li>1355 Market Street, Suite 420<br>San Francisco, CA 94103</li>
+          </ul>
+          <div class="footer-social mt-3">
+            <a href="https://www.facebook.com" aria-label="Facebook"><i class="fa-brands fa-facebook-f"></i></a>
+            <a href="https://www.twitter.com" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+            <a href="https://www.instagram.com" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+            <a href="https://www.linkedin.com" aria-label="LinkedIn"><i class="fa-brands fa-linkedin-in"></i></a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom text-center text-md-start mt-4">
+        © 2025 Agent Messengers. All Rights Reserved.
+      </div>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+  <script src="js/script.js"></script>
+</body>
+</html>

--- a/agentmessengers.com/blog-article-2.html
+++ b/agentmessengers.com/blog-article-2.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Designing Approval Workflows Agents Actually Love | Agent Messengers</title>
+  <meta name="description" content="Create compliance workflows that accelerate approvals without sacrificing oversight, using lessons from Agent Messengers clients.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700&family=Montserrat:wght@600;700;800&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuU8Q0Kw5y7FZ5Fk5clU61M0W6Nqd53Y2xZC2Y1Qd5kZw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">
+        Agent Messengers
+        <span>AI-managed outreach for regulated teams</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="mainNav">
+        <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
+          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="services.html" id="servicesDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Services</a>
+            <ul class="dropdown-menu" aria-labelledby="servicesDropdown">
+              <li><a class="dropdown-item" href="services.html#essentials">Essentials Suite</a></li>
+              <li><a class="dropdown-item" href="services.html#compliance">Compliance Plus</a></li>
+              <li><a class="dropdown-item" href="services.html#enterprise">Global Enterprise</a></li>
+            </ul>
+          </li>
+          <li class="nav-item"><a class="nav-link active" href="blog.html">Blog</a></li>
+          <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
+          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+          <li class="nav-item"><a class="btn btn-link login-link" href="https://agentmessengers.com/login">Login</a></li>
+          <li class="nav-item"><a class="btn btn-primary" href="demo.html">Request a Demo</a></li>
+        </ul>
+        <div class="theme-toggle">
+          <i class="fa-regular fa-sun"></i>
+          <div class="form-check form-switch m-0">
+            <input class="form-check-input" type="checkbox" role="switch" id="themeSwitch" aria-label="Toggle dark mode">
+          </div>
+          <i class="fa-regular fa-moon"></i>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main>
+    <section class="article-hero">
+      <div class="container text-white">
+        <h1 class="text-white">Designing Approval Workflows Agents Actually Love</h1>
+        <p class="lead text-white-50">Agents crave speed and clarity. Compliance demands accuracy. Here’s how top programs satisfy both.</p>
+      </div>
+    </section>
+
+    <section class="article-content">
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="col-lg-9">
+            <p>When approvals stall, agents fall back on outdated scripts or delay contacting clients. The resulting inconsistencies trigger regulator attention and erode trust. Agent Messengers customers have found a better path.</p>
+
+            <h2>Start with role clarity</h2>
+            <p>Every workflow begins with clearly defined responsibilities. Draft owners, reviewers, and approvers know exactly when their step begins thanks to automated notifications and dashboards.</p>
+
+            <h2>Automate the mundane</h2>
+            <p>Formatting checks, disclosure inserts, and archival naming conventions are handled by AI routines. Reviewers spend time on nuance, not on copy-pasting disclaimers.</p>
+
+            <h2>Give agents visibility</h2>
+            <p>Field teams can see exactly where each asset sits in the review queue. Transparent SLAs and progress indicators reduce inbound “status check” emails by up to 60%.</p>
+
+            <h2>Embed feedback loops</h2>
+            <p>Rejected submissions automatically include actionable commentary. Agents receive coaching prompts and best-practice examples to accelerate their next iteration.</p>
+
+            <h2>Celebrate adoption</h2>
+            <p>Success metrics are shared during sales huddles. When agents see approval times shrink and conversion rates climb, they become advocates for the process.</p>
+
+            <blockquote>“Our advisors went from reluctant participants to champions. They know compliance has their back, and compliance trusts the system,” says HarborPoint Advisory’s communications lead.</blockquote>
+
+            <p>The most effective workflows blend automation with human expertise. By meeting agents where they are, compliance leaders can drive adoption and maintain bulletproof audit trails.</p>
+
+            <div class="d-flex flex-wrap gap-3 mt-4">
+              <a href="blog.html" class="btn btn-primary">Back to insights</a>
+              <a href="services.html" class="btn btn-secondary-custom">Explore services</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="row gy-4">
+        <div class="col-md-4">
+          <div class="footer-brand">Agent Messengers</div>
+          <p class="footer-tagline">Empowering regulated teams to deliver compliant conversations at scale.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="d-inline-flex align-items-center gap-2">
+            Powered by <span class="fw-semibold">Netshow.AI</span>
+            <i class="fa-solid fa-arrow-up-right-from-square"></i>
+          </a>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Quick Links</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About Us</a></li>
+            <li><a href="services.html">Services</a></li>
+            <li><a href="products.html">Products</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Resources</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="blog.html">Blog</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="reviews.html">Reviews</a></li>
+            <li><a href="demo.html">Demo</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Legal</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="privacy.html">Privacy Policy</a></li>
+            <li><a href="terms.html">Terms of Use</a></li>
+            <li><a href="disclosure.html">Disclosure</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Contact</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="tel:+18885551234">+1 (888) 555-1234</a></li>
+            <li><a href="mailto:hello@agentmessengers.com">hello@agentmessengers.com</a></li>
+            <li>1355 Market Street, Suite 420<br>San Francisco, CA 94103</li>
+          </ul>
+          <div class="footer-social mt-3">
+            <a href="https://www.facebook.com" aria-label="Facebook"><i class="fa-brands fa-facebook-f"></i></a>
+            <a href="https://www.twitter.com" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+            <a href="https://www.instagram.com" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+            <a href="https://www.linkedin.com" aria-label="LinkedIn"><i class="fa-brands fa-linkedin-in"></i></a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom text-center text-md-start mt-4">
+        © 2025 Agent Messengers. All Rights Reserved.
+      </div>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+  <script src="js/script.js"></script>
+</body>
+</html>

--- a/agentmessengers.com/blog-article-3.html
+++ b/agentmessengers.com/blog-article-3.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Metrics that Prove Messaging Compliance | Agent Messengers</title>
+  <meta name="description" content="Discover the metrics that compliance and distribution leaders use to prove messaging readiness and satisfy regulators.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700&family=Montserrat:wght@600;700;800&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuU8Q0Kw5y7FZ5Fk5clU61M0W6Nqd53Y2xZC2Y1Qd5kZw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">
+        Agent Messengers
+        <span>AI-managed outreach for regulated teams</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="mainNav">
+        <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
+          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="services.html" id="servicesDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Services</a>
+            <ul class="dropdown-menu" aria-labelledby="servicesDropdown">
+              <li><a class="dropdown-item" href="services.html#essentials">Essentials Suite</a></li>
+              <li><a class="dropdown-item" href="services.html#compliance">Compliance Plus</a></li>
+              <li><a class="dropdown-item" href="services.html#enterprise">Global Enterprise</a></li>
+            </ul>
+          </li>
+          <li class="nav-item"><a class="nav-link active" href="blog.html">Blog</a></li>
+          <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
+          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+          <li class="nav-item"><a class="btn btn-link login-link" href="https://agentmessengers.com/login">Login</a></li>
+          <li class="nav-item"><a class="btn btn-primary" href="demo.html">Request a Demo</a></li>
+        </ul>
+        <div class="theme-toggle">
+          <i class="fa-regular fa-sun"></i>
+          <div class="form-check form-switch m-0">
+            <input class="form-check-input" type="checkbox" role="switch" id="themeSwitch" aria-label="Toggle dark mode">
+          </div>
+          <i class="fa-regular fa-moon"></i>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main>
+    <section class="article-hero">
+      <div class="container text-white">
+        <h1 class="text-white">Metrics that Prove Messaging Compliance</h1>
+        <p class="lead text-white-50">Numbers tell the story of trust. Track these metrics to show regulators and executives your program is airtight.</p>
+      </div>
+    </section>
+
+    <section class="article-content">
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="col-lg-9">
+            <p>Compliance leaders are expected to deliver dashboards that summarize readiness, risk, and results. The right metrics create common ground with distribution teams and regulators alike.</p>
+
+            <h2>Approval cycle time</h2>
+            <p>Measure the time from submission to final approval for each asset. Agent Messengers customers benchmark by product line and state to identify bottlenecks quickly.</p>
+
+            <h2>Policy coverage ratio</h2>
+            <p>This metric shows the percentage of policies with current, localized messaging. Dashboards highlight gaps so teams can prioritize updates before regulators do.</p>
+
+            <h2>Audit trail completeness</h2>
+            <p>Track how many assets include full reviewer notes, disclosure references, and system-generated timestamps. Anything less than 100% signals the need for training.</p>
+
+            <h2>Field engagement velocity</h2>
+            <p>Monitor how quickly agents deploy approved assets after release. Combining this with performance metrics reveals which regions need coaching or added support.</p>
+
+            <h2>Regulator satisfaction score</h2>
+            <p>After each exam or inquiry, ask regulators to rate the clarity of your documentation. High scores validate your processes and strengthen partnerships.</p>
+
+            <blockquote>“When examiners saw our dashboards, the tone changed. They knew we had command of every campaign,” recalls ShieldLine Insurance’s compliance VP.</blockquote>
+
+            <p>By standardizing these metrics, organizations turn compliance into a strategic advantage. The result: confident regulators, empowered agents, and loyal customers.</p>
+
+            <div class="d-flex flex-wrap gap-3 mt-4">
+              <a href="blog.html" class="btn btn-primary">Back to insights</a>
+              <a href="reviews.html" class="btn btn-secondary-custom">See customer results</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="row gy-4">
+        <div class="col-md-4">
+          <div class="footer-brand">Agent Messengers</div>
+          <p class="footer-tagline">Empowering regulated teams to deliver compliant conversations at scale.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="d-inline-flex align-items-center gap-2">
+            Powered by <span class="fw-semibold">Netshow.AI</span>
+            <i class="fa-solid fa-arrow-up-right-from-square"></i>
+          </a>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Quick Links</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About Us</a></li>
+            <li><a href="services.html">Services</a></li>
+            <li><a href="products.html">Products</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Resources</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="blog.html">Blog</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="reviews.html">Reviews</a></li>
+            <li><a href="demo.html">Demo</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Legal</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="privacy.html">Privacy Policy</a></li>
+            <li><a href="terms.html">Terms of Use</a></li>
+            <li><a href="disclosure.html">Disclosure</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Contact</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="tel:+18885551234">+1 (888) 555-1234</a></li>
+            <li><a href="mailto:hello@agentmessengers.com">hello@agentmessengers.com</a></li>
+            <li>1355 Market Street, Suite 420<br>San Francisco, CA 94103</li>
+          </ul>
+          <div class="footer-social mt-3">
+            <a href="https://www.facebook.com" aria-label="Facebook"><i class="fa-brands fa-facebook-f"></i></a>
+            <a href="https://www.twitter.com" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+            <a href="https://www.instagram.com" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+            <a href="https://www.linkedin.com" aria-label="LinkedIn"><i class="fa-brands fa-linkedin-in"></i></a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom text-center text-md-start mt-4">
+        © 2025 Agent Messengers. All Rights Reserved.
+      </div>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+  <script src="js/script.js"></script>
+</body>
+</html>

--- a/agentmessengers.com/blog.html
+++ b/agentmessengers.com/blog.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Insights &amp; Updates | Agent Messengers Blog</title>
+  <meta name="description" content="Read the latest insights on compliant messaging automation, localization strategies, and regulatory readiness from Agent Messengers.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700&family=Montserrat:wght@600;700;800&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuU8Q0Kw5y7FZ5Fk5clU61M0W6Nqd53Y2xZC2Y1Qd5kZw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">
+        Agent Messengers
+        <span>AI-managed outreach for regulated teams</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="mainNav">
+        <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
+          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="services.html" id="servicesDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Services</a>
+            <ul class="dropdown-menu" aria-labelledby="servicesDropdown">
+              <li><a class="dropdown-item" href="services.html#essentials">Essentials Suite</a></li>
+              <li><a class="dropdown-item" href="services.html#compliance">Compliance Plus</a></li>
+              <li><a class="dropdown-item" href="services.html#enterprise">Global Enterprise</a></li>
+            </ul>
+          </li>
+          <li class="nav-item"><a class="nav-link active" href="blog.html">Blog</a></li>
+          <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
+          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+          <li class="nav-item"><a class="btn btn-link login-link" href="https://agentmessengers.com/login">Login</a></li>
+          <li class="nav-item"><a class="btn btn-primary" href="demo.html">Request a Demo</a></li>
+        </ul>
+        <div class="theme-toggle">
+          <i class="fa-regular fa-sun"></i>
+          <div class="form-check form-switch m-0">
+            <input class="form-check-input" type="checkbox" role="switch" id="themeSwitch" aria-label="Toggle dark mode">
+          </div>
+          <i class="fa-regular fa-moon"></i>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main>
+    <section class="article-hero">
+      <div class="container text-white">
+        <div class="row align-items-center">
+          <div class="col-lg-8">
+            <h1 class="text-white">Insights to accelerate compliant outreach</h1>
+            <p class="lead text-white-50">Strategies, playbooks, and interviews with leaders redefining regulated communications.</p>
+          </div>
+          <div class="col-lg-4 text-lg-end text-white">
+            <div class="stat-chip bg-white text-dark d-inline-flex"><i class="fa-solid fa-newspaper text-primary"></i> Updated weekly</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="article-content">
+      <div class="container">
+        <div class="row g-4">
+          <div class="col-md-4">
+            <div class="blog-card h-100">
+              <img src="images/blog-1.svg" alt="Localization insights illustration" class="img-fluid mb-3">
+              <h3><a href="blog-article-1.html">5 Localization Wins from Insurance Leaders</a></h3>
+              <p class="text-muted-custom">Discover how bilingual teams trim revision cycles, manage regulator expectations, and increase policy renewals.</p>
+              <a href="blog-article-1.html" class="btn btn-link p-0">Read more <i class="fa-solid fa-arrow-right-long"></i></a>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="blog-card h-100">
+              <img src="images/blog-2.svg" alt="Workflow automation illustration" class="img-fluid mb-3">
+              <h3><a href="blog-article-2.html">Designing Approval Workflows Agents Actually Love</a></h3>
+              <p class="text-muted-custom">Practical steps to balance compliance oversight with rapid content launches across territories.</p>
+              <a href="blog-article-2.html" class="btn btn-link p-0">Read more <i class="fa-solid fa-arrow-right-long"></i></a>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="blog-card h-100">
+              <img src="images/blog-3.svg" alt="Analytics illustration" class="img-fluid mb-3">
+              <h3><a href="blog-article-3.html">Metrics that Prove Messaging Compliance</a></h3>
+              <p class="text-muted-custom">Learn the dashboards compliance chiefs rely on to defend decisions and coach field teams.</p>
+              <a href="blog-article-3.html" class="btn btn-link p-0">Read more <i class="fa-solid fa-arrow-right-long"></i></a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="row gy-4">
+        <div class="col-md-4">
+          <div class="footer-brand">Agent Messengers</div>
+          <p class="footer-tagline">Empowering regulated teams to deliver compliant conversations at scale.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="d-inline-flex align-items-center gap-2">
+            Powered by <span class="fw-semibold">Netshow.AI</span>
+            <i class="fa-solid fa-arrow-up-right-from-square"></i>
+          </a>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Quick Links</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About Us</a></li>
+            <li><a href="services.html">Services</a></li>
+            <li><a href="products.html">Products</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Resources</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="blog.html">Blog</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="reviews.html">Reviews</a></li>
+            <li><a href="demo.html">Demo</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Legal</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="privacy.html">Privacy Policy</a></li>
+            <li><a href="terms.html">Terms of Use</a></li>
+            <li><a href="disclosure.html">Disclosure</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Contact</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="tel:+18885551234">+1 (888) 555-1234</a></li>
+            <li><a href="mailto:hello@agentmessengers.com">hello@agentmessengers.com</a></li>
+            <li>1355 Market Street, Suite 420<br>San Francisco, CA 94103</li>
+          </ul>
+          <div class="footer-social mt-3">
+            <a href="https://www.facebook.com" aria-label="Facebook"><i class="fa-brands fa-facebook-f"></i></a>
+            <a href="https://www.twitter.com" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+            <a href="https://www.instagram.com" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+            <a href="https://www.linkedin.com" aria-label="LinkedIn"><i class="fa-brands fa-linkedin-in"></i></a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom text-center text-md-start mt-4">
+        © 2025 Agent Messengers. All Rights Reserved.
+      </div>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+  <script src="js/script.js"></script>
+</body>
+</html>

--- a/agentmessengers.com/contact.html
+++ b/agentmessengers.com/contact.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Contact Agent Messengers | Compliance Communication Experts</title>
+  <meta name="description" content="Connect with Agent Messengers for demos, support, or partnership discussions about compliant communication automation.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700&family=Montserrat:wght@600;700;800&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuU8Q0Kw5y7FZ5Fk5clU61M0W6Nqd53Y2xZC2Y1Qd5kZw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">
+        Agent Messengers
+        <span>AI-managed outreach for regulated teams</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="mainNav">
+        <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
+          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="services.html" id="servicesDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Services</a>
+            <ul class="dropdown-menu" aria-labelledby="servicesDropdown">
+              <li><a class="dropdown-item" href="services.html#essentials">Essentials Suite</a></li>
+              <li><a class="dropdown-item" href="services.html#compliance">Compliance Plus</a></li>
+              <li><a class="dropdown-item" href="services.html#enterprise">Global Enterprise</a></li>
+            </ul>
+          </li>
+          <li class="nav-item"><a class="nav-link" href="blog.html">Blog</a></li>
+          <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
+          <li class="nav-item"><a class="nav-link active" href="contact.html">Contact</a></li>
+          <li class="nav-item"><a class="btn btn-link login-link" href="https://agentmessengers.com/login">Login</a></li>
+          <li class="nav-item"><a class="btn btn-primary" href="demo.html">Request a Demo</a></li>
+        </ul>
+        <div class="theme-toggle">
+          <i class="fa-regular fa-sun"></i>
+          <div class="form-check form-switch m-0">
+            <input class="form-check-input" type="checkbox" role="switch" id="themeSwitch" aria-label="Toggle dark mode">
+          </div>
+          <i class="fa-regular fa-moon"></i>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main>
+    <section class="hero-section">
+      <div class="container">
+        <div class="row align-items-center gy-4">
+          <div class="col-lg-7 text-white">
+            <h1 class="text-white">Let’s coordinate your next compliant launch</h1>
+            <p class="lead text-white-75">Whether you’re exploring Agent Messengers or already scaling communications, our specialists are ready to help.</p>
+          </div>
+          <div class="col-lg-5 text-white text-lg-end">
+            <div class="stat-chip bg-white text-dark d-inline-flex"><i class="fa-solid fa-headset text-primary"></i> Response within 1 business day</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="article-content">
+      <div class="container">
+        <div class="row g-5">
+          <div class="col-lg-6">
+            <h2>Message our team</h2>
+            <form class="row g-3" data-form="contact">
+              <div class="col-md-6">
+                <label for="contactName" class="form-label">Full name*</label>
+                <input type="text" class="form-control" id="contactName" name="name" required>
+              </div>
+              <div class="col-md-6">
+                <label for="contactEmail" class="form-label">Email*</label>
+                <input type="email" class="form-control" id="contactEmail" name="email" required>
+              </div>
+              <div class="col-12">
+                <label for="contactCompany" class="form-label">Company</label>
+                <input type="text" class="form-control" id="contactCompany" name="company">
+              </div>
+              <div class="col-12">
+                <label for="contactMessage" class="form-label">How can we help?</label>
+                <textarea class="form-control" id="contactMessage" name="message" rows="5" required></textarea>
+              </div>
+              <div class="col-12">
+                <button type="submit" class="btn btn-primary">Submit message</button>
+              </div>
+              <div class="col-12">
+                <div class="small text-muted form-response"></div>
+              </div>
+            </form>
+          </div>
+          <div class="col-lg-6">
+            <h2>Visit our headquarters</h2>
+            <ul class="list-unstyled d-grid gap-2 mb-4">
+              <li><i class="fa-solid fa-location-dot text-primary"></i> 1355 Market Street, Suite 420, San Francisco, CA 94103</li>
+              <li><i class="fa-solid fa-phone text-primary"></i> <a href="tel:+18885551234">+1 (888) 555-1234</a></li>
+              <li><i class="fa-solid fa-envelope text-primary"></i> <a href="mailto:hello@agentmessengers.com">hello@agentmessengers.com</a></li>
+            </ul>
+            <div class="responsive-video" style="padding-bottom: 75%;">
+              <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3153.086353177791!2d-122.41941568468176!3d37.776779579759775!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x8085809c3bc6d1df%3A0xeadf88dc5ec52ff5!2s1355%20Market%20St%2C%20San%20Francisco%2C%20CA%2094103!5e0!3m2!1sen!2sus!4v1700000000000" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+            </div>
+            <p class="small text-muted mt-3">Prefer to connect virtually? <a href="https://calendly.com/netshow/discovery-call" target="_blank" rel="noopener">Book your strategy call</a> to meet with our compliance advisors.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="row gy-4">
+        <div class="col-md-4">
+          <div class="footer-brand">Agent Messengers</div>
+          <p class="footer-tagline">Empowering regulated teams to deliver compliant conversations at scale.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="d-inline-flex align-items-center gap-2">
+            Powered by <span class="fw-semibold">Netshow.AI</span>
+            <i class="fa-solid fa-arrow-up-right-from-square"></i>
+          </a>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Quick Links</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About Us</a></li>
+            <li><a href="services.html">Services</a></li>
+            <li><a href="products.html">Products</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Resources</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="blog.html">Blog</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="reviews.html">Reviews</a></li>
+            <li><a href="demo.html">Demo</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Legal</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="privacy.html">Privacy Policy</a></li>
+            <li><a href="terms.html">Terms of Use</a></li>
+            <li><a href="disclosure.html">Disclosure</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Contact</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="tel:+18885551234">+1 (888) 555-1234</a></li>
+            <li><a href="mailto:hello@agentmessengers.com">hello@agentmessengers.com</a></li>
+            <li>1355 Market Street, Suite 420<br>San Francisco, CA 94103</li>
+          </ul>
+          <div class="footer-social mt-3">
+            <a href="https://www.facebook.com" aria-label="Facebook"><i class="fa-brands fa-facebook-f"></i></a>
+            <a href="https://www.twitter.com" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+            <a href="https://www.instagram.com" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+            <a href="https://www.linkedin.com" aria-label="LinkedIn"><i class="fa-brands fa-linkedin-in"></i></a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom text-center text-md-start mt-4">
+        © 2025 Agent Messengers. All Rights Reserved.
+      </div>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+  <script src="js/script.js"></script>
+</body>
+</html>

--- a/agentmessengers.com/css/style.css
+++ b/agentmessengers.com/css/style.css
@@ -1,0 +1,490 @@
+/*
+  Agent Messengers Custom Stylesheet
+  ---------------------------------
+  Implements the brand palette, typography, and reusable components
+  referenced throughout the Agent Messengers marketing site.
+*/
+
+/* Typography */
+body {
+  --primary-color: #4A90E2;
+  --secondary-color: #F5A623;
+  --text-color: #333333;
+  --background-color: #FFFFFF;
+  --surface-color: #F3F6FB;
+  --border-color: rgba(74, 144, 226, 0.15);
+  --muted-color: #5F6F82;
+  --gradient-primary: linear-gradient(135deg, rgba(74, 144, 226, 0.18), rgba(245, 166, 35, 0.2));
+  font-family: 'Lato', sans-serif;
+  color: var(--text-color);
+  background-color: var(--background-color);
+  line-height: 1.6;
+}
+
+body.dark-mode {
+  --text-color: #FFFFFF;
+  --background-color: #121212;
+  --surface-color: #1E1E1E;
+  --border-color: rgba(255, 255, 255, 0.1);
+  --muted-color: #B5C8FF;
+  background-color: var(--background-color);
+  color: var(--text-color);
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 700;
+  color: var(--text-color);
+}
+
+p {
+  margin-bottom: 1rem;
+}
+
+a {
+  color: var(--primary-color);
+  text-decoration: none;
+}
+
+a:hover, a:focus {
+  color: var(--secondary-color);
+  text-decoration: underline;
+}
+
+/* Layout Helpers */
+section {
+  padding: 5rem 0;
+}
+
+.bg-surface {
+  background-color: var(--surface-color);
+}
+
+.text-muted-custom {
+  color: var(--muted-color) !important;
+}
+
+.shadow-soft {
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+}
+
+/* Header */
+.navbar {
+  position: sticky;
+  top: 0;
+  z-index: 1030;
+  background-color: var(--background-color);
+  box-shadow: 0 2px 16px rgba(15, 23, 42, 0.08);
+  transition: background-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.navbar-brand {
+  font-weight: 700;
+  font-size: 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.navbar-brand span {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--muted-color);
+}
+
+.nav-link {
+  font-weight: 600;
+  color: var(--text-color) !important;
+  margin-right: 0.75rem;
+  transition: color 0.2s ease;
+}
+
+.nav-link:hover, .nav-link:focus, .nav-link.active {
+  color: var(--primary-color) !important;
+}
+
+.dropdown-menu {
+  border-radius: 1rem;
+  border: 1px solid var(--border-color);
+  background-color: var(--background-color);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.dropdown-item {
+  font-weight: 500;
+  color: var(--text-color);
+  padding: 0.65rem 1.25rem;
+}
+
+.dropdown-item:hover, .dropdown-item:focus {
+  background-color: rgba(74, 144, 226, 0.08);
+  color: var(--primary-color);
+}
+
+.login-link {
+  color: var(--text-color);
+  font-weight: 600;
+  padding: 0.375rem 0.75rem;
+  margin-right: 0.5rem;
+}
+
+.login-link:hover, .login-link:focus {
+  color: var(--primary-color);
+  text-decoration: none;
+}
+
+.btn-primary {
+  background-color: var(--primary-color);
+  border-color: var(--primary-color);
+  border-radius: 999px;
+  font-weight: 600;
+  padding: 0.5rem 1.5rem;
+}
+
+.btn-primary:hover, .btn-primary:focus {
+  background-color: #2F74C8;
+  border-color: #2F74C8;
+}
+
+.btn-secondary-custom {
+  background-color: var(--secondary-color);
+  border-color: var(--secondary-color);
+  color: #1F2937;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.btn-outline-light-custom {
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  color: #fff;
+  font-weight: 600;
+}
+
+/* Theme toggle */
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: 1rem;
+  font-weight: 600;
+  color: var(--muted-color);
+}
+
+.theme-toggle .form-check-input {
+  width: 2.75rem;
+  height: 1.35rem;
+  cursor: pointer;
+  border: 1px solid var(--border-color);
+  background-color: rgba(74, 144, 226, 0.25);
+}
+
+.theme-toggle .form-check-input:checked {
+  background-color: var(--secondary-color);
+  border-color: var(--secondary-color);
+}
+
+/* Hero Section */
+.hero-section {
+  padding: 6rem 0 4rem;
+  background: var(--gradient-primary);
+}
+
+.hero-section .card {
+  border-radius: 1.5rem;
+  border: none;
+  background-color: var(--background-color);
+  box-shadow: 0 20px 40px rgba(74, 144, 226, 0.08);
+}
+
+.hero-section h1 {
+  font-size: 2.8rem;
+  line-height: 1.2;
+}
+
+.hero-section p.lead {
+  font-size: 1.2rem;
+  color: var(--muted-color);
+}
+
+.hero-image {
+  max-width: 100%;
+  height: auto;
+}
+
+.highlight-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 700;
+  color: var(--secondary-color);
+}
+
+.highlight-link i {
+  transition: transform 0.2s ease;
+}
+
+.highlight-link:hover i {
+  transform: translateX(4px);
+}
+
+/* Feature Cards */
+.step-card, .feature-card, .testimonial-card, .plan-card, .product-card, .case-card {
+  border: 1px solid var(--border-color);
+  border-radius: 1.5rem;
+  background-color: var(--background-color);
+  padding: 2rem;
+  height: 100%;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.step-card:hover, .feature-card:hover, .testimonial-card:hover, .plan-card:hover, .product-card:hover, .case-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.12);
+}
+
+.icon-circle {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background-color: rgba(74, 144, 226, 0.12);
+  color: var(--primary-color);
+  font-size: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+/* Testimonials */
+.testimonial-card p {
+  font-style: italic;
+}
+
+.testimonial-card img {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  margin-bottom: 1rem;
+}
+
+/* Tables */
+.table-custom {
+  border-radius: 1rem;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+}
+
+.table-custom thead {
+  background-color: rgba(74, 144, 226, 0.1);
+}
+
+.table-custom th, .table-custom td {
+  vertical-align: middle;
+  padding: 1.25rem;
+}
+
+/* Forms */
+.form-control, .form-select {
+  border-radius: 0.85rem;
+  border: 1px solid var(--border-color);
+  padding: 0.75rem 1rem;
+  background-color: var(--background-color);
+  color: var(--text-color);
+}
+
+.form-control:focus, .form-select:focus {
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 0.25rem rgba(74, 144, 226, 0.15);
+}
+
+.form-floating>.form-control:focus~label, .form-floating>.form-control:not(:placeholder-shown)~label {
+  color: var(--primary-color);
+}
+
+/* Demo Layout */
+.demo-hero {
+  padding: 5rem 0;
+}
+
+.demo-form {
+  border-radius: 1.5rem;
+  border: 1px solid var(--border-color);
+  background-color: var(--background-color);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.12);
+  padding: 2rem;
+}
+
+.demo-form .form-check-label {
+  font-size: 0.85rem;
+  color: var(--muted-color);
+}
+
+.responsive-video {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+  border-radius: 1.5rem;
+  box-shadow: 0 20px 40px rgba(74, 144, 226, 0.16);
+}
+
+.responsive-video iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+/* Blog */
+.blog-card img {
+  border-radius: 1rem;
+}
+
+.blog-card h3 {
+  font-size: 1.25rem;
+}
+
+.article-hero {
+  padding: 6rem 0 3rem;
+  background: var(--gradient-primary);
+}
+
+.article-content {
+  padding: 3rem 0;
+}
+
+.article-content h2 {
+  margin-top: 2.5rem;
+}
+
+blockquote {
+  border-left: 4px solid var(--secondary-color);
+  padding-left: 1rem;
+  font-style: italic;
+  color: var(--muted-color);
+}
+
+/* FAQ */
+.accordion-button {
+  font-weight: 600;
+  border-radius: 1rem;
+}
+
+.accordion-button:not(.collapsed) {
+  background-color: rgba(74, 144, 226, 0.08);
+  color: var(--primary-color);
+}
+
+.accordion-item {
+  border: none;
+  margin-bottom: 1rem;
+  border-radius: 1rem !important;
+  border: 1px solid var(--border-color);
+}
+
+/* Footer */
+.site-footer {
+  background-color: #0F172A;
+  color: #E2E8F0;
+  padding: 4rem 0 2rem;
+}
+
+body.dark-mode .site-footer {
+  background-color: #050B17;
+}
+
+.site-footer a {
+  color: #E2E8F0;
+}
+
+.site-footer a:hover {
+  color: var(--secondary-color);
+}
+
+.footer-brand {
+  font-family: 'Montserrat', sans-serif;
+  font-weight: 700;
+  font-size: 1.35rem;
+}
+
+.footer-tagline {
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.footer-heading {
+  font-weight: 700;
+  font-size: 1rem;
+  margin-bottom: 1.25rem;
+  text-transform: uppercase;
+}
+
+.footer-social a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background-color: rgba(255, 255, 255, 0.08);
+  margin-right: 0.5rem;
+  transition: transform 0.2s ease;
+}
+
+.footer-social a:hover {
+  transform: translateY(-4px);
+}
+
+.footer-bottom {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+/* Utilities */
+.badge-soft {
+  background-color: rgba(245, 166, 35, 0.2);
+  color: var(--secondary-color);
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.stat-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  background-color: rgba(74, 144, 226, 0.12);
+  color: var(--primary-color);
+  font-weight: 600;
+}
+
+@media (max-width: 992px) {
+  .navbar-nav {
+    margin-top: 1rem;
+  }
+
+  .theme-toggle {
+    margin-top: 1rem;
+  }
+
+  .hero-section {
+    text-align: center;
+  }
+
+  .hero-section h1 {
+    font-size: 2.3rem;
+  }
+
+  .plan-card, .feature-card, .testimonial-card, .step-card {
+    margin-bottom: 1.5rem;
+  }
+}

--- a/agentmessengers.com/demo.html
+++ b/agentmessengers.com/demo.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Request a Demo | Agent Messengers &amp; AgentProgrammingTool.com</title>
+  <meta name="description" content="Book a personalized walkthrough of Agent Messengers and see how it powers the agentprogrammingtool.com experience for compliant automation.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700&family=Montserrat:wght@600;700;800&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuU8Q0Kw5y7FZ5Fk5clU61M0W6Nqd53Y2xZC2Y1Qd5kZw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">
+        Agent Messengers
+        <span>AI-managed outreach for regulated teams</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="mainNav">
+        <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
+          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="services.html" id="servicesDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Services</a>
+            <ul class="dropdown-menu" aria-labelledby="servicesDropdown">
+              <li><a class="dropdown-item" href="services.html#essentials">Essentials Suite</a></li>
+              <li><a class="dropdown-item" href="services.html#compliance">Compliance Plus</a></li>
+              <li><a class="dropdown-item" href="services.html#enterprise">Global Enterprise</a></li>
+            </ul>
+          </li>
+          <li class="nav-item"><a class="nav-link" href="blog.html">Blog</a></li>
+          <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
+          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+          <li class="nav-item"><a class="btn btn-link login-link" href="https://agentmessengers.com/login">Login</a></li>
+          <li class="nav-item"><a class="btn btn-primary" href="demo.html">Request a Demo</a></li>
+        </ul>
+        <div class="theme-toggle">
+          <i class="fa-regular fa-sun"></i>
+          <div class="form-check form-switch m-0">
+            <input class="form-check-input" type="checkbox" role="switch" id="themeSwitch" aria-label="Toggle dark mode">
+          </div>
+          <i class="fa-regular fa-moon"></i>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main>
+    <section class="demo-hero">
+      <div class="container">
+        <div class="row g-5">
+          <div class="col-lg-6">
+            <span class="badge-soft mb-3">Interactive walkthrough</span>
+            <h1>See agentprogrammingtool.com powered by Agent Messengers</h1>
+            <p class="lead text-muted-custom">Experience how compliant AI agents craft multi-channel scripts, monitor approvals, and publish updates inside the agentprogrammingtool.com workspace.</p>
+            <ul class="list-unstyled d-grid gap-2 mb-4">
+              <li><i class="fa-solid fa-circle-check text-success"></i> Step-by-step tour of orchestration boards and compliance workflows</li>
+              <li><i class="fa-solid fa-circle-check text-success"></i> Live preview of multilingual content generation and testing harness</li>
+              <li><i class="fa-solid fa-circle-check text-success"></i> Roadmap discussion tailored to your regulator expectations</li>
+            </ul>
+            <div class="responsive-video mb-4">
+              <iframe src="https://www.youtube.com/embed/d8OFVQgl6pM" title="Agent Messengers Demo" allowfullscreen></iframe>
+            </div>
+            <div class="d-flex flex-wrap gap-3">
+              <div class="stat-chip"><i class="fa-solid fa-user-shield"></i> 98% reviewer satisfaction</div>
+              <div class="stat-chip"><i class="fa-solid fa-trophy"></i> 2025 RegTech Innovation Award</div>
+            </div>
+          </div>
+          <div class="col-lg-6">
+            <div class="demo-form">
+              <h2 class="mb-3">Book your personalized session</h2>
+              <p class="text-muted-custom">Complete the form to schedule a 30-minute strategy call with our compliance specialists.</p>
+              <form class="row g-3" data-form="demo">
+                <div class="col-12">
+                  <label for="demoEmail" class="form-label">Work email*</label>
+                  <input type="email" class="form-control" id="demoEmail" name="email" required>
+                </div>
+                <div class="col-md-6">
+                  <label for="demoName" class="form-label">Full name*</label>
+                  <input type="text" class="form-control" id="demoName" name="name" required>
+                </div>
+                <div class="col-md-6">
+                  <label for="demoRole" class="form-label">Role*</label>
+                  <select id="demoRole" class="form-select" name="role" required>
+                    <option value="" selected disabled>Select role</option>
+                    <option>Chief Compliance Officer</option>
+                    <option>Operations Leader</option>
+                    <option>Distribution Executive</option>
+                    <option>Technology Partner</option>
+                  </select>
+                </div>
+                <div class="col-md-6">
+                  <label for="demoCountry" class="form-label">Country*</label>
+                  <select id="demoCountry" class="form-select" name="country" required>
+                    <option value="" selected disabled>Select country</option>
+                    <option>United States</option>
+                    <option>Canada</option>
+                    <option>United Kingdom</option>
+                    <option>Australia</option>
+                    <option>Other</option>
+                  </select>
+                </div>
+                <div class="col-md-6">
+                  <label for="demoCompany" class="form-label">Company*</label>
+                  <input type="text" class="form-control" id="demoCompany" name="company" required>
+                </div>
+                <div class="col-12">
+                  <label for="demoHear" class="form-label">How did you hear about us?</label>
+                  <select id="demoHear" class="form-select" name="referral">
+                    <option>Industry conference</option>
+                    <option>Regulator referral</option>
+                    <option>Partner integration</option>
+                    <option>Social media</option>
+                    <option>Other</option>
+                  </select>
+                </div>
+                <div class="col-12">
+                  <div class="form-check">
+                    <input class="form-check-input" type="checkbox" value="yes" id="demoNewsletter">
+                    <label class="form-check-label" for="demoNewsletter">I’d like ongoing updates about agentprogrammingtool.com enhancements.</label>
+                  </div>
+                </div>
+                <div class="col-12">
+                  <button type="submit" class="btn btn-primary w-100">Request a demo</button>
+                </div>
+                <div class="col-12">
+                  <div class="small text-muted form-response"></div>
+                </div>
+                <div class="col-12">
+                  <p class="small text-muted">By submitting, you agree to Agent Messengers’ <a href="privacy.html">Privacy Policy</a>.</p>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="row gy-4">
+        <div class="col-md-4">
+          <div class="footer-brand">Agent Messengers</div>
+          <p class="footer-tagline">Empowering regulated teams to deliver compliant conversations at scale.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="d-inline-flex align-items-center gap-2">
+            Powered by <span class="fw-semibold">Netshow.AI</span>
+            <i class="fa-solid fa-arrow-up-right-from-square"></i>
+          </a>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Quick Links</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About Us</a></li>
+            <li><a href="services.html">Services</a></li>
+            <li><a href="products.html">Products</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Resources</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="blog.html">Blog</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="reviews.html">Reviews</a></li>
+            <li><a href="demo.html">Demo</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Legal</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="privacy.html">Privacy Policy</a></li>
+            <li><a href="terms.html">Terms of Use</a></li>
+            <li><a href="disclosure.html">Disclosure</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Contact</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="tel:+18885551234">+1 (888) 555-1234</a></li>
+            <li><a href="mailto:hello@agentmessengers.com">hello@agentmessengers.com</a></li>
+            <li>1355 Market Street, Suite 420<br>San Francisco, CA 94103</li>
+          </ul>
+          <div class="footer-social mt-3">
+            <a href="https://www.facebook.com" aria-label="Facebook"><i class="fa-brands fa-facebook-f"></i></a>
+            <a href="https://www.twitter.com" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+            <a href="https://www.instagram.com" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+            <a href="https://www.linkedin.com" aria-label="LinkedIn"><i class="fa-brands fa-linkedin-in"></i></a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom text-center text-md-start mt-4">
+        © 2025 Agent Messengers. All Rights Reserved.
+      </div>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+  <script src="js/script.js"></script>
+</body>
+</html>

--- a/agentmessengers.com/disclosure.html
+++ b/agentmessengers.com/disclosure.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Disclosure Statement | Agent Messengers</title>
+  <meta name="description" content="Read the Agent Messengers disclosure regarding affiliate relationships, regulatory status, and testimonial statements.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700&family=Montserrat:wght@600;700;800&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuU8Q0Kw5y7FZ5Fk5clU61M0W6Nqd53Y2xZC2Y1Qd5kZw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">
+        Agent Messengers
+        <span>AI-managed outreach for regulated teams</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="mainNav">
+        <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
+          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="services.html" id="servicesDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Services</a>
+            <ul class="dropdown-menu" aria-labelledby="servicesDropdown">
+              <li><a class="dropdown-item" href="services.html#essentials">Essentials Suite</a></li>
+              <li><a class="dropdown-item" href="services.html#compliance">Compliance Plus</a></li>
+              <li><a class="dropdown-item" href="services.html#enterprise">Global Enterprise</a></li>
+            </ul>
+          </li>
+          <li class="nav-item"><a class="nav-link" href="blog.html">Blog</a></li>
+          <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
+          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+          <li class="nav-item"><a class="btn btn-link login-link" href="https://agentmessengers.com/login">Login</a></li>
+          <li class="nav-item"><a class="btn btn-primary" href="demo.html">Request a Demo</a></li>
+        </ul>
+        <div class="theme-toggle">
+          <i class="fa-regular fa-sun"></i>
+          <div class="form-check form-switch m-0">
+            <input class="form-check-input" type="checkbox" role="switch" id="themeSwitch" aria-label="Toggle dark mode">
+          </div>
+          <i class="fa-regular fa-moon"></i>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main>
+    <section class="article-hero">
+      <div class="container text-white">
+        <h1 class="text-white">Disclosure Statement</h1>
+        <p class="lead text-white-50">Transparency about our business relationships and testimonials.</p>
+      </div>
+    </section>
+
+    <section class="article-content">
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="col-lg-9">
+            <h2>1. Regulatory status</h2>
+            <p>Agent Messengers is a software provider and does not operate as a licensed insurance agency or broker. Clients remain responsible for meeting licensing, filing, and regulatory obligations associated with their communications.</p>
+
+            <h2>2. Affiliate relationships</h2>
+            <p>From time to time, we partner with technology vendors, consultancies, or integration firms. We may receive referral fees when customers choose to work with these partners. Such relationships do not influence our product roadmap or the recommendations we provide.</p>
+
+            <h2>3. Testimonials and case studies</h2>
+            <p>Testimonials appearing on this site reflect the real experiences of Agent Messengers customers. Individual results may vary based on organizational readiness, regulatory environment, and engagement with our success team.</p>
+
+            <h2>4. Forward-looking statements</h2>
+            <p>Any statements about future product capabilities or regulatory outcomes are forward-looking in nature. Actual results may differ due to market conditions, regulatory updates, and customer adoption.</p>
+
+            <h2>5. Data usage</h2>
+            <p>Metrics presented in case studies and marketing materials are provided for informational purposes. They are based on aggregated customer data and are not a guarantee of future performance.</p>
+
+            <h2>6. Contact</h2>
+            <p>For additional disclosures or regulatory documentation, please contact legal@agentmessengers.com.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="row gy-4">
+        <div class="col-md-4">
+          <div class="footer-brand">Agent Messengers</div>
+          <p class="footer-tagline">Empowering regulated teams to deliver compliant conversations at scale.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="d-inline-flex align-items-center gap-2">
+            Powered by <span class="fw-semibold">Netshow.AI</span>
+            <i class="fa-solid fa-arrow-up-right-from-square"></i>
+          </a>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Quick Links</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About Us</a></li>
+            <li><a href="services.html">Services</a></li>
+            <li><a href="products.html">Products</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Resources</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="blog.html">Blog</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="reviews.html">Reviews</a></li>
+            <li><a href="demo.html">Demo</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Legal</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="privacy.html">Privacy Policy</a></li>
+            <li><a href="terms.html">Terms of Use</a></li>
+            <li><a href="disclosure.html">Disclosure</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Contact</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="tel:+18885551234">+1 (888) 555-1234</a></li>
+            <li><a href="mailto:hello@agentmessengers.com">hello@agentmessengers.com</a></li>
+            <li>1355 Market Street, Suite 420<br>San Francisco, CA 94103</li>
+          </ul>
+          <div class="footer-social mt-3">
+            <a href="https://www.facebook.com" aria-label="Facebook"><i class="fa-brands fa-facebook-f"></i></a>
+            <a href="https://www.twitter.com" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+            <a href="https://www.instagram.com" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+            <a href="https://www.linkedin.com" aria-label="LinkedIn"><i class="fa-brands fa-linkedin-in"></i></a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom text-center text-md-start mt-4">
+        © 2025 Agent Messengers. All Rights Reserved.
+      </div>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+  <script src="js/script.js"></script>
+</body>
+</html>

--- a/agentmessengers.com/faq.html
+++ b/agentmessengers.com/faq.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Frequently Asked Questions | Agent Messengers</title>
+  <meta name="description" content="Answers to common questions about Agent Messengers’ AI-managed compliant communications platform.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700&family=Montserrat:wght@600;700;800&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuU8Q0Kw5y7FZ5Fk5clU61M0W6Nqd53Y2xZC2Y1Qd5kZw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">
+        Agent Messengers
+        <span>AI-managed outreach for regulated teams</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="mainNav">
+        <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
+          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="services.html" id="servicesDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Services</a>
+            <ul class="dropdown-menu" aria-labelledby="servicesDropdown">
+              <li><a class="dropdown-item" href="services.html#essentials">Essentials Suite</a></li>
+              <li><a class="dropdown-item" href="services.html#compliance">Compliance Plus</a></li>
+              <li><a class="dropdown-item" href="services.html#enterprise">Global Enterprise</a></li>
+            </ul>
+          </li>
+          <li class="nav-item"><a class="nav-link" href="blog.html">Blog</a></li>
+          <li class="nav-item"><a class="nav-link active" href="faq.html">FAQ</a></li>
+          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+          <li class="nav-item"><a class="btn btn-link login-link" href="https://agentmessengers.com/login">Login</a></li>
+          <li class="nav-item"><a class="btn btn-primary" href="demo.html">Request a Demo</a></li>
+        </ul>
+        <div class="theme-toggle">
+          <i class="fa-regular fa-sun"></i>
+          <div class="form-check form-switch m-0">
+            <input class="form-check-input" type="checkbox" role="switch" id="themeSwitch" aria-label="Toggle dark mode">
+          </div>
+          <i class="fa-regular fa-moon"></i>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main>
+    <section class="article-hero">
+      <div class="container text-white">
+        <h1 class="text-white">Frequently Asked Questions</h1>
+        <p class="lead text-white-50">Quick answers about implementation, compliance controls, and support.</p>
+      </div>
+    </section>
+
+    <section class="article-content">
+      <div class="container">
+        <div class="accordion" id="faqAccordion">
+          <div class="accordion-item">
+            <h2 class="accordion-header" id="faqOne">
+              <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="true" aria-controls="collapseOne">
+                How long does it take to launch Agent Messengers?
+              </button>
+            </h2>
+            <div id="collapseOne" class="accordion-collapse collapse show" aria-labelledby="faqOne" data-bs-parent="#faqAccordion">
+              <div class="accordion-body">
+                Most teams go live in six to eight weeks. Our onboarding squad configures templates, compliance rules, and integrations while training reviewers and field champions.
+              </div>
+            </div>
+          </div>
+          <div class="accordion-item">
+            <h2 class="accordion-header" id="faqTwo">
+              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
+                What regulatory frameworks does Agent Messengers support?
+              </button>
+            </h2>
+            <div id="collapseTwo" class="accordion-collapse collapse" aria-labelledby="faqTwo" data-bs-parent="#faqAccordion">
+              <div class="accordion-body">
+                We maintain rule libraries for state Departments of Insurance, FINRA communications, NAIC Model Laws, and EMEA conduct standards. Custom rules can be added for your jurisdiction with audit-ready documentation.
+              </div>
+            </div>
+          </div>
+          <div class="accordion-item">
+            <h2 class="accordion-header" id="faqThree">
+              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
+                Does the platform integrate with our CRM and policy systems?
+              </button>
+            </h2>
+            <div id="collapseThree" class="accordion-collapse collapse" aria-labelledby="faqThree" data-bs-parent="#faqAccordion">
+              <div class="accordion-body">
+                Yes. We provide native connectors for Salesforce, Microsoft Dynamics, Guidewire, Vlocity, and RESTful APIs for custom stacks. Our integration architects ensure data governance requirements are met.
+              </div>
+            </div>
+          </div>
+          <div class="accordion-item">
+            <h2 class="accordion-header" id="faqFour">
+              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFour" aria-expanded="false" aria-controls="collapseFour">
+                How does Agent Messengers handle localization quality?
+              </button>
+            </h2>
+            <div id="collapseFour" class="accordion-collapse collapse" aria-labelledby="faqFour" data-bs-parent="#faqAccordion">
+              <div class="accordion-body">
+                AI-generated translations are routed through bilingual reviewer pods with access to contextual glossaries. Approval metrics and reader feedback loop into the model to continuously refine output.
+              </div>
+            </div>
+          </div>
+          <div class="accordion-item">
+            <h2 class="accordion-header" id="faqFive">
+              <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFive" aria-expanded="false" aria-controls="collapseFive">
+                What support is available after launch?
+              </button>
+            </h2>
+            <div id="collapseFive" class="accordion-collapse collapse" aria-labelledby="faqFive" data-bs-parent="#faqAccordion">
+              <div class="accordion-body">
+                Every subscription includes 24/5 live chat, quarterly compliance strategy reviews, and a dedicated success manager for escalations. Enterprise clients receive onsite workshops and regulator prep sessions.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="row gy-4">
+        <div class="col-md-4">
+          <div class="footer-brand">Agent Messengers</div>
+          <p class="footer-tagline">Empowering regulated teams to deliver compliant conversations at scale.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="d-inline-flex align-items-center gap-2">
+            Powered by <span class="fw-semibold">Netshow.AI</span>
+            <i class="fa-solid fa-arrow-up-right-from-square"></i>
+          </a>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Quick Links</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About Us</a></li>
+            <li><a href="services.html">Services</a></li>
+            <li><a href="products.html">Products</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Resources</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="blog.html">Blog</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="reviews.html">Reviews</a></li>
+            <li><a href="demo.html">Demo</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Legal</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="privacy.html">Privacy Policy</a></li>
+            <li><a href="terms.html">Terms of Use</a></li>
+            <li><a href="disclosure.html">Disclosure</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Contact</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="tel:+18885551234">+1 (888) 555-1234</a></li>
+            <li><a href="mailto:hello@agentmessengers.com">hello@agentmessengers.com</a></li>
+            <li>1355 Market Street, Suite 420<br>San Francisco, CA 94103</li>
+          </ul>
+          <div class="footer-social mt-3">
+            <a href="https://www.facebook.com" aria-label="Facebook"><i class="fa-brands fa-facebook-f"></i></a>
+            <a href="https://www.twitter.com" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+            <a href="https://www.instagram.com" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+            <a href="https://www.linkedin.com" aria-label="LinkedIn"><i class="fa-brands fa-linkedin-in"></i></a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom text-center text-md-start mt-4">
+        © 2025 Agent Messengers. All Rights Reserved.
+      </div>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+  <script src="js/script.js"></script>
+</body>
+</html>

--- a/agentmessengers.com/images/blog-1.svg
+++ b/agentmessengers.com/images/blog-1.svg
@@ -1,0 +1,7 @@
+<svg width="320" height="200" viewBox="0 0 320 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Blog illustration 1</title>
+  <rect width="320" height="200" fill="#EAF4FF" rx="24"/>
+  <path d="M40 150 L120 70 L170 110 L220 60 L280 130" stroke="#4A90E2" stroke-width="8" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="120" cy="70" r="10" fill="#F5A623"/>
+  <circle cx="220" cy="60" r="10" fill="#F5A623"/>
+</svg>

--- a/agentmessengers.com/images/blog-2.svg
+++ b/agentmessengers.com/images/blog-2.svg
@@ -1,0 +1,8 @@
+<svg width="320" height="200" viewBox="0 0 320 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Blog illustration 2</title>
+  <rect width="320" height="200" fill="#FFF5E8" rx="24"/>
+  <rect x="60" y="50" width="200" height="40" rx="12" fill="#4A90E2" opacity="0.2"/>
+  <rect x="60" y="110" width="160" height="40" rx="12" fill="#F5A623" opacity="0.3"/>
+  <circle cx="110" cy="70" r="10" fill="#4A90E2"/>
+  <circle cx="180" cy="130" r="12" fill="#F5A623"/>
+</svg>

--- a/agentmessengers.com/images/blog-3.svg
+++ b/agentmessengers.com/images/blog-3.svg
@@ -1,0 +1,7 @@
+<svg width="320" height="200" viewBox="0 0 320 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Blog illustration 3</title>
+  <rect width="320" height="200" fill="#E8F8F6" rx="24"/>
+  <rect x="48" y="48" width="224" height="40" rx="20" fill="#4A90E2" opacity="0.25"/>
+  <rect x="48" y="104" width="180" height="40" rx="20" fill="#F5A623" opacity="0.35"/>
+  <rect x="48" y="148" width="140" height="24" rx="12" fill="#4A90E2" opacity="0.2"/>
+</svg>

--- a/agentmessengers.com/images/case-insurance.svg
+++ b/agentmessengers.com/images/case-insurance.svg
@@ -1,0 +1,6 @@
+<svg width="320" height="200" viewBox="0 0 320 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Case study illustration</title>
+  <rect width="320" height="200" fill="#EEF1FF" rx="24"/>
+  <rect x="60" y="52" width="200" height="96" rx="18" fill="#FFFFFF" stroke="#4A90E2" stroke-width="4"/>
+  <path d="M90 130c20-28 40-20 60-48 8-10 20-10 40 12" stroke="#F5A623" stroke-width="6" fill="none" stroke-linecap="round"/>
+</svg>

--- a/agentmessengers.com/images/hero-dashboard.svg
+++ b/agentmessengers.com/images/hero-dashboard.svg
@@ -1,0 +1,31 @@
+<svg width="640" height="480" viewBox="0 0 640 480" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Dashboard illustration</title>
+  <desc id="desc">Stylized illustration representing analytics messaging</desc>
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4A90E2"/>
+      <stop offset="100%" stop-color="#F5A623"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="640" height="480" fill="#EEF4FF"/>
+  <rect x="80" y="60" width="480" height="360" rx="24" fill="#fff" stroke="url(#grad)" stroke-width="4"/>
+  <rect x="120" y="110" width="160" height="28" rx="14" fill="#4A90E2" opacity="0.15"/>
+  <rect x="300" y="110" width="200" height="28" rx="14" fill="#4A90E2" opacity="0.3"/>
+  <rect x="120" y="160" width="360" height="18" rx="9" fill="#4A90E2" opacity="0.2"/>
+  <rect x="120" y="190" width="200" height="18" rx="9" fill="#4A90E2" opacity="0.12"/>
+  <rect x="120" y="220" width="320" height="18" rx="9" fill="#4A90E2" opacity="0.18"/>
+  <g transform="translate(120 260)">
+    <rect x="0" y="0" width="140" height="140" rx="18" fill="#4A90E2" opacity="0.1"/>
+    <polyline points="24,96 60,56 92,84 116,36" fill="none" stroke="#4A90E2" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="24" cy="96" r="6" fill="#F5A623"/>
+    <circle cx="60" cy="56" r="6" fill="#F5A623"/>
+    <circle cx="92" cy="84" r="6" fill="#F5A623"/>
+    <circle cx="116" cy="36" r="6" fill="#F5A623"/>
+  </g>
+  <g transform="translate(280 260)">
+    <rect x="0" y="0" width="220" height="140" rx="18" fill="#4A90E2" opacity="0.08"/>
+    <rect x="28" y="28" width="160" height="16" rx="8" fill="#4A90E2" opacity="0.5"/>
+    <rect x="28" y="56" width="120" height="16" rx="8" fill="#4A90E2" opacity="0.35"/>
+    <rect x="28" y="84" width="100" height="16" rx="8" fill="#F5A623" opacity="0.7"/>
+  </g>
+</svg>

--- a/agentmessengers.com/images/logo-fastcompany.svg
+++ b/agentmessengers.com/images/logo-fastcompany.svg
@@ -1,0 +1,5 @@
+<svg width="160" height="60" viewBox="0 0 160 60" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Fast Company style logo placeholder</title>
+  <rect width="160" height="60" fill="#FFFFFF"/>
+  <text x="50%" y="50%" text-anchor="middle" font-family="Montserrat, Arial" font-size="22" fill="#333333" dominant-baseline="middle">FastCompany*</text>
+</svg>

--- a/agentmessengers.com/images/logo-forbes.svg
+++ b/agentmessengers.com/images/logo-forbes.svg
@@ -1,0 +1,5 @@
+<svg width="160" height="60" viewBox="0 0 160 60" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Forbes style logo placeholder</title>
+  <rect width="160" height="60" fill="#FFFFFF"/>
+  <text x="50%" y="50%" text-anchor="middle" font-family="Montserrat, Arial" font-size="28" fill="#4A90E2" dominant-baseline="middle">Forbes*</text>
+</svg>

--- a/agentmessengers.com/images/logo-insurtechdaily.svg
+++ b/agentmessengers.com/images/logo-insurtechdaily.svg
@@ -1,0 +1,5 @@
+<svg width="160" height="60" viewBox="0 0 160 60" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Insurtech Daily logo placeholder</title>
+  <rect width="160" height="60" fill="#EAEFFF"/>
+  <text x="50%" y="50%" text-anchor="middle" font-family="Montserrat, Arial" font-size="20" fill="#4A90E2" dominant-baseline="middle">InsurtechDaily*</text>
+</svg>

--- a/agentmessengers.com/images/logo-techcrunch.svg
+++ b/agentmessengers.com/images/logo-techcrunch.svg
@@ -1,0 +1,5 @@
+<svg width="160" height="60" viewBox="0 0 160 60" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">TechCrunch style logo placeholder</title>
+  <rect width="160" height="60" fill="#121212"/>
+  <text x="50%" y="50%" text-anchor="middle" font-family="Montserrat, Arial" font-size="24" fill="#F5A623" dominant-baseline="middle">TechCrunch*</text>
+</svg>

--- a/agentmessengers.com/images/product-audio.svg
+++ b/agentmessengers.com/images/product-audio.svg
@@ -1,0 +1,7 @@
+<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Audio kit illustration</title>
+  <rect width="200" height="200" fill="#E8F9F1" rx="32"/>
+  <path d="M80 60h40v80H80z" fill="#4A90E2" opacity="0.7"/>
+  <path d="M70 84c-14 0-14 32 0 32" stroke="#4A90E2" stroke-width="8" fill="none"/>
+  <path d="M130 84c14 0 14 32 0 32" stroke="#F5A623" stroke-width="8" fill="none"/>
+</svg>

--- a/agentmessengers.com/images/product-kit.svg
+++ b/agentmessengers.com/images/product-kit.svg
@@ -1,0 +1,7 @@
+<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Field kit illustration</title>
+  <rect width="200" height="200" fill="#FFF2E5" rx="32"/>
+  <rect x="44" y="60" width="112" height="80" rx="20" fill="#FFFFFF" stroke="#F5A623" stroke-width="4"/>
+  <circle cx="84" cy="100" r="10" fill="#4A90E2"/>
+  <circle cx="116" cy="100" r="10" fill="#4A90E2"/>
+</svg>

--- a/agentmessengers.com/images/product-playbook.svg
+++ b/agentmessengers.com/images/product-playbook.svg
@@ -1,0 +1,7 @@
+<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Playbook illustration</title>
+  <rect width="200" height="200" fill="#EAF6FF" rx="32"/>
+  <rect x="56" y="40" width="96" height="120" rx="16" fill="#FFFFFF" stroke="#4A90E2" stroke-width="4"/>
+  <line x1="56" y1="88" x2="152" y2="88" stroke="#F5A623" stroke-width="6"/>
+  <line x1="56" y1="120" x2="152" y2="120" stroke="#4A90E2" stroke-width="6"/>
+</svg>

--- a/agentmessengers.com/images/team-ava.svg
+++ b/agentmessengers.com/images/team-ava.svg
@@ -1,0 +1,6 @@
+<svg width="180" height="180" viewBox="0 0 180 180" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Portrait placeholder of Ava Chen</title>
+  <rect width="180" height="180" fill="#EAEFFF" rx="28"/>
+  <circle cx="90" cy="70" r="40" fill="#4A90E2" opacity="0.75"/>
+  <rect x="42" y="120" width="96" height="44" rx="22" fill="#F5A623" opacity="0.6"/>
+</svg>

--- a/agentmessengers.com/images/team-malik.svg
+++ b/agentmessengers.com/images/team-malik.svg
@@ -1,0 +1,6 @@
+<svg width="180" height="180" viewBox="0 0 180 180" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Portrait placeholder of Malik Rhodes</title>
+  <rect width="180" height="180" fill="#FFF2E6" rx="28"/>
+  <circle cx="90" cy="70" r="40" fill="#F5A623" opacity="0.75"/>
+  <rect x="40" y="120" width="100" height="44" rx="22" fill="#4A90E2" opacity="0.6"/>
+</svg>

--- a/agentmessengers.com/images/team-sofia.svg
+++ b/agentmessengers.com/images/team-sofia.svg
@@ -1,0 +1,6 @@
+<svg width="180" height="180" viewBox="0 0 180 180" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Portrait placeholder of Sofia Patel</title>
+  <rect width="180" height="180" fill="#E9F8F9" rx="28"/>
+  <circle cx="90" cy="70" r="40" fill="#4A90E2" opacity="0.6"/>
+  <rect x="44" y="120" width="92" height="44" rx="22" fill="#F5A623" opacity="0.65"/>
+</svg>

--- a/agentmessengers.com/images/testimonial-diego.svg
+++ b/agentmessengers.com/images/testimonial-diego.svg
@@ -1,0 +1,6 @@
+<svg width="160" height="160" viewBox="0 0 160 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Portrait placeholder of Diego</title>
+  <rect width="160" height="160" fill="#FFF4E6" rx="20"/>
+  <circle cx="80" cy="60" r="32" fill="#F5A623" opacity="0.8"/>
+  <path d="M40 132c8-24 32-32 40-32s32 8 40 32" fill="#4A90E2" opacity="0.6"/>
+</svg>

--- a/agentmessengers.com/images/testimonial-linh.svg
+++ b/agentmessengers.com/images/testimonial-linh.svg
@@ -1,0 +1,6 @@
+<svg width="160" height="160" viewBox="0 0 160 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Portrait placeholder of Linh</title>
+  <rect width="160" height="160" fill="#E6F8F5" rx="20"/>
+  <circle cx="80" cy="60" r="32" fill="#4A90E2" opacity="0.65"/>
+  <path d="M40 132c10-22 32-28 40-28s30 6 40 28" fill="#F5A623" opacity="0.55"/>
+</svg>

--- a/agentmessengers.com/images/testimonial-simone.svg
+++ b/agentmessengers.com/images/testimonial-simone.svg
@@ -1,0 +1,6 @@
+<svg width="160" height="160" viewBox="0 0 160 160" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title">
+  <title id="title">Portrait placeholder of Simone</title>
+  <rect width="160" height="160" fill="#E8F1FF" rx="20"/>
+  <circle cx="80" cy="60" r="32" fill="#4A90E2" opacity="0.8"/>
+  <path d="M40 132c6-26 32-36 40-36s34 10 40 36" fill="#F5A623" opacity="0.6"/>
+</svg>

--- a/agentmessengers.com/index.html
+++ b/agentmessengers.com/index.html
@@ -1,0 +1,315 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Agent Messengers | AI-Orchestrated Compliance Communications</title>
+  <meta name="description" content="Agent Messengers helps regulated insurance and advisory networks deliver personalized, compliant client updates with AI-managed messaging workflows.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700&family=Montserrat:wght@600;700;800&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuU8Q0Kw5y7FZ5Fk5clU61M0W6Nqd53Y2xZC2Y1Qd5kZw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">
+        Agent Messengers
+        <span>AI-managed outreach for regulated teams</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="mainNav">
+        <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
+          <li class="nav-item"><a class="nav-link active" href="index.html">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="services.html" id="servicesDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Services</a>
+            <ul class="dropdown-menu" aria-labelledby="servicesDropdown">
+              <li><a class="dropdown-item" href="services.html#essentials">Essentials Suite</a></li>
+              <li><a class="dropdown-item" href="services.html#compliance">Compliance Plus</a></li>
+              <li><a class="dropdown-item" href="services.html#enterprise">Global Enterprise</a></li>
+            </ul>
+          </li>
+          <li class="nav-item"><a class="nav-link" href="blog.html">Blog</a></li>
+          <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
+          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+          <li class="nav-item"><a class="btn btn-link login-link" href="https://agentmessengers.com/login">Login</a></li>
+          <li class="nav-item"><a class="btn btn-primary" href="demo.html">Request a Demo</a></li>
+        </ul>
+        <div class="theme-toggle">
+          <i class="fa-regular fa-sun"></i>
+          <div class="form-check form-switch m-0">
+            <input class="form-check-input" type="checkbox" role="switch" id="themeSwitch" aria-label="Toggle dark mode">
+          </div>
+          <i class="fa-regular fa-moon"></i>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main>
+    <section class="hero-section">
+      <div class="container">
+        <div class="row align-items-center g-5">
+          <div class="col-lg-6">
+            <span class="badge-soft mb-3">Purpose-Built for Insurance &amp; Advisory Networks</span>
+            <h1>Deliver compliant client updates in minutes, not days.</h1>
+            <p class="lead">Agent Messengers orchestrates AI-managed microbriefings across SMS, email, voice, and portals so licensed agents can serve policyholders faster without compromising regulatory guardrails.</p>
+            <div class="stat-chip mb-4"><i class="fa-solid fa-bolt"></i> 92% faster approval cycles</div>
+            <form class="row g-2 align-items-center" data-form="hero">
+              <div class="col-12 col-sm-8">
+                <label for="heroEmail" class="visually-hidden">Email address</label>
+                <div class="input-group">
+                  <span class="input-group-text"><i class="fa-regular fa-envelope"></i></span>
+                  <input type="email" class="form-control" id="heroEmail" name="email" placeholder="Work email" required>
+                </div>
+              </div>
+              <div class="col-12 col-sm-4 d-grid">
+                <button type="submit" class="btn btn-primary">Get started</button>
+              </div>
+              <div class="col-12">
+                <p class="small text-muted-custom mb-1">No spam. Just a readiness assessment tailored to your territory.</p>
+                <div class="form-response small"></div>
+              </div>
+            </form>
+            <a class="highlight-link mt-3" href="https://calendly.com/netshow/discovery-call" target="_blank" rel="noopener">
+              Book Your Call Now <i class="fa-solid fa-arrow-up-right-from-square"></i>
+            </a>
+          </div>
+          <div class="col-lg-6">
+            <div class="card p-4 shadow-soft">
+              <img src="images/hero-dashboard.svg" class="hero-image" alt="Agent Messengers analytics dashboard illustration">
+              <div class="mt-3 text-muted-custom small">Real-time orchestration view showing message approvals, localization progress, and field engagement.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="bg-surface">
+      <div class="container">
+        <div class="row justify-content-center text-center mb-5">
+          <div class="col-lg-8">
+            <h2>How Agent Messengers Works</h2>
+            <p class="text-muted-custom">We transform fragmented handoffs into orchestrated, compliant conversations.</p>
+          </div>
+        </div>
+        <div class="row g-4">
+          <div class="col-md-4">
+            <div class="step-card h-100">
+              <div class="icon-circle"><i class="fa-solid fa-magnifying-glass-chart"></i></div>
+              <h3>Assess &amp; ingest</h3>
+              <p>Upload policy bulletins, rate filings, and scripts. Our ingestion studio standardizes formats, maps regulatory requirements, and tags distribution cohorts automatically.</p>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="step-card h-100">
+              <div class="icon-circle"><i class="fa-solid fa-robot"></i></div>
+              <h3>Generate playbooks</h3>
+              <p>The orchestration engine drafts multi-channel playbooks, localizes language, and runs instant compliance simulations before sharing with designated reviewers.</p>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="step-card h-100">
+              <div class="icon-circle"><i class="fa-solid fa-paper-plane"></i></div>
+              <h3>Launch &amp; learn</h3>
+              <p>Distribute to agents in the field with tracked approvals. Adaptive analytics highlight performance, flag exceptions, and continuously improve messaging accuracy.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <div class="container">
+        <div class="row justify-content-center text-center mb-5">
+          <div class="col-lg-8">
+            <h2>Everything your compliance team wished for</h2>
+            <p class="text-muted-custom">From jurisdiction-aware guardrails to multilingual delivery, Agent Messengers removes the friction from regulated outreach.</p>
+          </div>
+        </div>
+        <div class="row g-4">
+          <div class="col-md-6 col-lg-4">
+            <div class="feature-card">
+              <div class="icon-circle"><i class="fa-solid fa-shield-heart"></i></div>
+              <h3>Regulatory intelligence</h3>
+              <p>Cross-checks every asset against state DOI bulletins, FINRA guidance, and your internal rules to maintain spotless audit trails.</p>
+            </div>
+          </div>
+          <div class="col-md-6 col-lg-4">
+            <div class="feature-card">
+              <div class="icon-circle"><i class="fa-solid fa-language"></i></div>
+              <h3>Instant localization</h3>
+              <p>Auto-generates culturally attuned translations with human-in-the-loop review flows for Spanish, Korean, Mandarin, and more.</p>
+            </div>
+          </div>
+          <div class="col-md-6 col-lg-4">
+            <div class="feature-card">
+              <div class="icon-circle"><i class="fa-solid fa-cloud-arrow-up"></i></div>
+              <h3>Channel-ready assets</h3>
+              <p>Deploy optimized content across SMS, voice drops, agent portals, and CRM journeys without juggling file conversions.</p>
+            </div>
+          </div>
+          <div class="col-md-6 col-lg-4">
+            <div class="feature-card">
+              <div class="icon-circle"><i class="fa-solid fa-people-group"></i></div>
+              <h3>Field enablement hub</h3>
+              <p>Curate pitch decks, script updates, and micro-learning modules tailored to each region and distribution partner.</p>
+            </div>
+          </div>
+          <div class="col-md-6 col-lg-4">
+            <div class="feature-card">
+              <div class="icon-circle"><i class="fa-solid fa-gauge-high"></i></div>
+              <h3>Engagement telemetry</h3>
+              <p>Visualize which agents launch, customize, or stall campaigns so you can drive coaching before deadlines slip.</p>
+            </div>
+          </div>
+          <div class="col-md-6 col-lg-4">
+            <div class="feature-card">
+              <div class="icon-circle"><i class="fa-solid fa-lock-check"></i></div>
+              <h3>Trust-centered controls</h3>
+              <p>SOC 2 Type II-ready permissions ensure only credentialed reviewers can ship messaging, with version tracking baked in.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="bg-surface">
+      <div class="container">
+        <div class="row justify-content-center text-center mb-5">
+          <div class="col-lg-8">
+            <h2>Trusted by agents who refuse to compromise on compliance</h2>
+          </div>
+        </div>
+        <div class="row g-4">
+          <div class="col-md-4">
+            <div class="testimonial-card text-center p-4 h-100">
+              <img src="images/testimonial-simone.svg" alt="Portrait of Simone Harris">
+              <h5>Simone Harris</h5>
+              <span class="text-muted-custom d-block mb-3">Director of Client Communications, ShieldLine Insurance</span>
+              <p>“Our annuity desk cut message approval times from two weeks to 48 hours. Agent Messengers keeps every state filing in sync so my team can focus on coaching agents.”</p>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="testimonial-card text-center p-4 h-100">
+              <img src="images/testimonial-diego.svg" alt="Portrait of Diego Álvarez">
+              <h5>Diego Álvarez</h5>
+              <span class="text-muted-custom d-block mb-3">VP of Distribution, Meridian Mutual</span>
+              <p>“Localization used to be our bottleneck. Now bilingual producers receive ready-to-send scripts that already factor in local disclosures.”</p>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="testimonial-card text-center p-4 h-100">
+              <img src="images/testimonial-linh.svg" alt="Portrait of Linh Nguyen">
+              <h5>Linh Nguyen</h5>
+              <span class="text-muted-custom d-block mb-3">Chief Compliance Officer, HarborPoint Advisory</span>
+              <p>“Our regulators loved the audit trails. Every outbound campaign now has a transparent record without my analysts chasing screenshots.”</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <div class="container">
+        <div class="row align-items-center gy-4">
+          <div class="col-lg-4">
+            <p class="text-muted-custom text-uppercase fw-bold mb-2">Featured In</p>
+            <h3>Industry analysts highlight our compliance rigor</h3>
+          </div>
+          <div class="col-lg-8">
+            <div class="row g-3 align-items-center">
+              <div class="col-6 col-md-3 text-center"><img src="images/logo-forbes.svg" class="img-fluid" alt="Forbes"></div>
+              <div class="col-6 col-md-3 text-center"><img src="images/logo-techcrunch.svg" class="img-fluid" alt="TechCrunch"></div>
+              <div class="col-6 col-md-3 text-center"><img src="images/logo-fastcompany.svg" class="img-fluid" alt="Fast Company"></div>
+              <div class="col-6 col-md-3 text-center"><img src="images/logo-insurtechdaily.svg" class="img-fluid" alt="Insurtech Daily"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="py-5" style="background: linear-gradient(135deg, rgba(74,144,226,0.9), rgba(245,166,35,0.85));">
+      <div class="container">
+        <div class="row align-items-center text-center text-lg-start">
+          <div class="col-lg-8 text-white">
+            <h2 class="text-white">Ready to orchestrate every client update with confidence?</h2>
+            <p class="mb-0">Join the compliance-first agencies who use Agent Messengers to coordinate launches, satisfy regulators, and protect the client experience.</p>
+          </div>
+          <div class="col-lg-4 mt-4 mt-lg-0 d-flex justify-content-lg-end justify-content-center gap-3">
+            <a href="demo.html" class="btn btn-outline-light-custom">See the demo</a>
+            <a href="services.html" class="btn btn-secondary-custom">Explore plans</a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="row gy-4">
+        <div class="col-md-4">
+          <div class="footer-brand">Agent Messengers</div>
+          <p class="footer-tagline">Empowering regulated teams to deliver compliant conversations at scale.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="d-inline-flex align-items-center gap-2">
+            Powered by <span class="fw-semibold">Netshow.AI</span>
+            <i class="fa-solid fa-arrow-up-right-from-square"></i>
+          </a>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Quick Links</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About Us</a></li>
+            <li><a href="services.html">Services</a></li>
+            <li><a href="products.html">Products</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Resources</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="blog.html">Blog</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="reviews.html">Reviews</a></li>
+            <li><a href="demo.html">Demo</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Legal</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="privacy.html">Privacy Policy</a></li>
+            <li><a href="terms.html">Terms of Use</a></li>
+            <li><a href="disclosure.html">Disclosure</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Contact</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="tel:+18885551234">+1 (888) 555-1234</a></li>
+            <li><a href="mailto:hello@agentmessengers.com">hello@agentmessengers.com</a></li>
+            <li>1355 Market Street, Suite 420<br>San Francisco, CA 94103</li>
+          </ul>
+          <div class="footer-social mt-3">
+            <a href="https://www.facebook.com" aria-label="Facebook"><i class="fa-brands fa-facebook-f"></i></a>
+            <a href="https://www.twitter.com" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+            <a href="https://www.instagram.com" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+            <a href="https://www.linkedin.com" aria-label="LinkedIn"><i class="fa-brands fa-linkedin-in"></i></a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom text-center text-md-start mt-4">
+        © 2025 Agent Messengers. All Rights Reserved.
+      </div>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+  <script src="js/script.js"></script>
+</body>
+</html>

--- a/agentmessengers.com/js/script.js
+++ b/agentmessengers.com/js/script.js
@@ -1,0 +1,76 @@
+/*
+  Agent Messengers Interaction Logic
+  ----------------------------------
+  Handles theme persistence, lightweight form feedback, and accessibility
+  enhancements required across the marketing experience.
+*/
+
+document.addEventListener('DOMContentLoaded', () => {
+  const themeSwitch = document.getElementById('themeSwitch');
+  const root = document.documentElement;
+  const storedTheme = localStorage.getItem('agentmessengers-theme');
+
+  const applyTheme = (mode) => {
+    if (mode === 'dark') {
+      document.body.classList.add('dark-mode');
+      root.setAttribute('data-bs-theme', 'dark');
+    } else {
+      document.body.classList.remove('dark-mode');
+      root.setAttribute('data-bs-theme', 'light');
+    }
+  };
+
+  if (storedTheme) {
+    applyTheme(storedTheme);
+    if (themeSwitch) {
+      themeSwitch.checked = storedTheme === 'dark';
+    }
+  } else {
+    // Respect system preference on first visit
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    applyTheme(prefersDark ? 'dark' : 'light');
+    if (themeSwitch) {
+      themeSwitch.checked = prefersDark;
+    }
+  }
+
+  if (themeSwitch) {
+    themeSwitch.addEventListener('change', (event) => {
+      const mode = event.target.checked ? 'dark' : 'light';
+      applyTheme(mode);
+      localStorage.setItem('agentmessengers-theme', mode);
+    });
+  }
+
+  // Simple form handling to provide instant user feedback in a static build
+  const forms = document.querySelectorAll('form[data-form]');
+  forms.forEach((form) => {
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const responseTarget = form.querySelector('.form-response');
+      const submitButton = form.querySelector('button[type="submit"]');
+      const defaultLabel = submitButton ? submitButton.textContent : '';
+
+      if (submitButton) {
+        submitButton.disabled = true;
+        submitButton.textContent = 'Sending…';
+      }
+
+      window.setTimeout(() => {
+        if (responseTarget) {
+          responseTarget.textContent = 'Thank you! Our team will follow up shortly.';
+          responseTarget.classList.remove('text-danger');
+          responseTarget.classList.add('text-success');
+        } else {
+          window.alert('Thank you! Our team will follow up shortly.');
+        }
+
+        if (submitButton) {
+          submitButton.disabled = false;
+          submitButton.textContent = defaultLabel || 'Submit';
+        }
+        form.reset();
+      }, 600);
+    });
+  });
+});

--- a/agentmessengers.com/privacy.html
+++ b/agentmessengers.com/privacy.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy | Agent Messengers</title>
+  <meta name="description" content="Read Agent Messengers’ privacy policy outlining data collection, usage, and security practices for our communications platform.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700&family=Montserrat:wght@600;700;800&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuU8Q0Kw5y7FZ5Fk5clU61M0W6Nqd53Y2xZC2Y1Qd5kZw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">
+        Agent Messengers
+        <span>AI-managed outreach for regulated teams</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="mainNav">
+        <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
+          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="services.html" id="servicesDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Services</a>
+            <ul class="dropdown-menu" aria-labelledby="servicesDropdown">
+              <li><a class="dropdown-item" href="services.html#essentials">Essentials Suite</a></li>
+              <li><a class="dropdown-item" href="services.html#compliance">Compliance Plus</a></li>
+              <li><a class="dropdown-item" href="services.html#enterprise">Global Enterprise</a></li>
+            </ul>
+          </li>
+          <li class="nav-item"><a class="nav-link" href="blog.html">Blog</a></li>
+          <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
+          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+          <li class="nav-item"><a class="btn btn-link login-link" href="https://agentmessengers.com/login">Login</a></li>
+          <li class="nav-item"><a class="btn btn-primary" href="demo.html">Request a Demo</a></li>
+        </ul>
+        <div class="theme-toggle">
+          <i class="fa-regular fa-sun"></i>
+          <div class="form-check form-switch m-0">
+            <input class="form-check-input" type="checkbox" role="switch" id="themeSwitch" aria-label="Toggle dark mode">
+          </div>
+          <i class="fa-regular fa-moon"></i>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main>
+    <section class="article-hero">
+      <div class="container text-white">
+        <h1 class="text-white">Privacy Policy</h1>
+        <p class="lead text-white-50">Effective January 1, 2025</p>
+      </div>
+    </section>
+
+    <section class="article-content">
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="col-lg-9">
+            <h2>1. Overview</h2>
+            <p>Agent Messengers (“we,” “our,” or “us”) respects the confidentiality of our customers, prospects, and partners. This Privacy Policy explains how we collect, use, and protect personal information when you engage with agentmessengers.com or the Agent Messengers platform.</p>
+
+            <h2>2. Information we collect</h2>
+            <p>We collect information you voluntarily provide, such as contact details, job titles, and form submissions. We also collect usage data, device information, and log files to improve our services. When our customers upload content to the platform, they are responsible for ensuring they have authority to share that data.</p>
+
+            <h2>3. How we use information</h2>
+            <p>We use personal information to deliver services, respond to inquiries, personalize product experiences, send transactional emails, and comply with legal obligations. Aggregated, de-identified data may be used for analytics and product development.</p>
+
+            <h2>4. Sharing and disclosure</h2>
+            <p>We do not sell personal information. We share data with trusted vendors that support our infrastructure, analytics, and customer success operations under confidentiality agreements. We may disclose information to comply with legal requests or to protect our rights and the safety of our users.</p>
+
+            <h2>5. Security</h2>
+            <p>Agent Messengers maintains administrative, technical, and physical safeguards aligned with SOC 2 Type II controls. Access to customer data is restricted to authorized personnel following least-privilege principles.</p>
+
+            <h2>6. Your choices</h2>
+            <p>You may update contact details, unsubscribe from marketing communications, or request deletion of personal data by contacting <a href="mailto:privacy@agentmessengers.com">privacy@agentmessengers.com</a>. Platform users should coordinate data requests through their organization’s administrator.</p>
+
+            <h2>7. International transfers</h2>
+            <p>If we transfer data outside of your jurisdiction, we apply appropriate safeguards such as Standard Contractual Clauses and conduct privacy impact assessments.</p>
+
+            <h2>8. Children’s privacy</h2>
+            <p>Agent Messengers is designed for professional use and is not directed to children under 16. We do not knowingly collect personal information from children.</p>
+
+            <h2>9. Policy updates</h2>
+            <p>We may update this Privacy Policy to reflect new features or regulations. We will post revisions on this page with an updated effective date.</p>
+
+            <h2>10. Contact</h2>
+            <p>Questions about this policy can be directed to privacy@agentmessengers.com or to our headquarters at 1355 Market Street, Suite 420, San Francisco, CA 94103.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="row gy-4">
+        <div class="col-md-4">
+          <div class="footer-brand">Agent Messengers</div>
+          <p class="footer-tagline">Empowering regulated teams to deliver compliant conversations at scale.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="d-inline-flex align-items-center gap-2">
+            Powered by <span class="fw-semibold">Netshow.AI</span>
+            <i class="fa-solid fa-arrow-up-right-from-square"></i>
+          </a>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Quick Links</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About Us</a></li>
+            <li><a href="services.html">Services</a></li>
+            <li><a href="products.html">Products</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Resources</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="blog.html">Blog</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="reviews.html">Reviews</a></li>
+            <li><a href="demo.html">Demo</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Legal</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="privacy.html">Privacy Policy</a></li>
+            <li><a href="terms.html">Terms of Use</a></li>
+            <li><a href="disclosure.html">Disclosure</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Contact</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="tel:+18885551234">+1 (888) 555-1234</a></li>
+            <li><a href="mailto:hello@agentmessengers.com">hello@agentmessengers.com</a></li>
+            <li>1355 Market Street, Suite 420<br>San Francisco, CA 94103</li>
+          </ul>
+          <div class="footer-social mt-3">
+            <a href="https://www.facebook.com" aria-label="Facebook"><i class="fa-brands fa-facebook-f"></i></a>
+            <a href="https://www.twitter.com" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+            <a href="https://www.instagram.com" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+            <a href="https://www.linkedin.com" aria-label="LinkedIn"><i class="fa-brands fa-linkedin-in"></i></a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom text-center text-md-start mt-4">
+        © 2025 Agent Messengers. All Rights Reserved.
+      </div>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+  <script src="js/script.js"></script>
+</body>
+</html>

--- a/agentmessengers.com/products.html
+++ b/agentmessengers.com/products.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Products | Agent Messengers Enablement Assets</title>
+  <meta name="description" content="Explore Agent Messengers playbooks, compliance toolkits, and audio assets that help regulated field teams deliver consistent client communications.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700&family=Montserrat:wght@600;700;800&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuU8Q0Kw5y7FZ5Fk5clU61M0W6Nqd53Y2xZC2Y1Qd5kZw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">
+        Agent Messengers
+        <span>AI-managed outreach for regulated teams</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="mainNav">
+        <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
+          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="services.html" id="servicesDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Services</a>
+            <ul class="dropdown-menu" aria-labelledby="servicesDropdown">
+              <li><a class="dropdown-item" href="services.html#essentials">Essentials Suite</a></li>
+              <li><a class="dropdown-item" href="services.html#compliance">Compliance Plus</a></li>
+              <li><a class="dropdown-item" href="services.html#enterprise">Global Enterprise</a></li>
+            </ul>
+          </li>
+          <li class="nav-item"><a class="nav-link" href="blog.html">Blog</a></li>
+          <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
+          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+          <li class="nav-item"><a class="btn btn-link login-link" href="https://agentmessengers.com/login">Login</a></li>
+          <li class="nav-item"><a class="btn btn-primary" href="demo.html">Request a Demo</a></li>
+        </ul>
+        <div class="theme-toggle">
+          <i class="fa-regular fa-sun"></i>
+          <div class="form-check form-switch m-0">
+            <input class="form-check-input" type="checkbox" role="switch" id="themeSwitch" aria-label="Toggle dark mode">
+          </div>
+          <i class="fa-regular fa-moon"></i>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main>
+    <section class="hero-section">
+      <div class="container">
+        <div class="row align-items-center gy-4">
+          <div class="col-lg-8 text-white">
+            <h1 class="text-white">Enablement resources that keep every conversation on message</h1>
+            <p class="lead text-white-75">Our curated digital and physical kits extend the Agent Messengers platform into every agent’s toolkit.</p>
+          </div>
+          <div class="col-lg-4 text-lg-end text-center text-white">
+            <div class="stat-chip bg-white text-dark d-inline-flex"><i class="fa-solid fa-box-open text-primary"></i> Ships worldwide</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <div class="container">
+        <div class="row g-4">
+          <div class="col-md-4">
+            <div class="product-card h-100 text-center p-4">
+              <img src="images/product-playbook.svg" alt="Agent Messengers playbook" class="mb-3" width="120" height="120">
+              <h3>Response Playbook Library</h3>
+              <p class="text-muted-custom">Downloadable templates with pre-approved language for policy changes, rate adjustments, and claims updates.</p>
+              <p class="fw-bold mb-1">$499 / annual license</p>
+              <a href="contact.html" class="btn btn-primary">Request access</a>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="product-card h-100 text-center p-4">
+              <img src="images/product-kit.svg" alt="Compliance field kit" class="mb-3" width="120" height="120">
+              <h3>Compliance Field Kit</h3>
+              <p class="text-muted-custom">Physical toolkit with printed micro-guides, scenario flashcards, and QR-coded policy references for in-person meetings.</p>
+              <p class="fw-bold mb-1">$289 / kit</p>
+              <a href="https://agentmessengers.com/store/field-kit" class="btn btn-secondary-custom">Buy now</a>
+            </div>
+          </div>
+          <div class="col-md-4">
+            <div class="product-card h-100 text-center p-4">
+              <img src="images/product-audio.svg" alt="Localized audio pack" class="mb-3" width="120" height="120">
+              <h3>Localized Audio Pack</h3>
+              <p class="text-muted-custom">Professionally voiced scripts in Spanish, Korean, and Vietnamese for outbound voice drops and IVR updates.</p>
+              <p class="fw-bold mb-1">$179 / language</p>
+              <a href="contact.html" class="btn btn-primary">Schedule preview</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="bg-surface">
+      <div class="container">
+        <div class="row align-items-center gy-4">
+          <div class="col-lg-6">
+            <h2>Bundle for enterprise savings</h2>
+            <p class="text-muted-custom">Combine platform subscriptions with enablement kits to unlock volume pricing, custom branding, and co-branded event support.</p>
+          </div>
+          <div class="col-lg-6">
+            <div class="step-card h-100">
+              <h3 class="mb-3">What’s included in the bundle?</h3>
+              <ul class="list-unstyled d-grid gap-2">
+                <li><i class="fa-solid fa-check text-success"></i> Quarterly playbook refresh with regulatory updates</li>
+                <li><i class="fa-solid fa-check text-success"></i> Co-branded launch campaign assets</li>
+                <li><i class="fa-solid fa-check text-success"></i> Exclusive invites to compliance roundtables</li>
+              </ul>
+              <a href="demo.html" class="btn btn-secondary-custom mt-3">Discuss bundle</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="row gy-4">
+        <div class="col-md-4">
+          <div class="footer-brand">Agent Messengers</div>
+          <p class="footer-tagline">Empowering regulated teams to deliver compliant conversations at scale.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="d-inline-flex align-items-center gap-2">
+            Powered by <span class="fw-semibold">Netshow.AI</span>
+            <i class="fa-solid fa-arrow-up-right-from-square"></i>
+          </a>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Quick Links</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About Us</a></li>
+            <li><a href="services.html">Services</a></li>
+            <li><a href="products.html">Products</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Resources</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="blog.html">Blog</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="reviews.html">Reviews</a></li>
+            <li><a href="demo.html">Demo</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Legal</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="privacy.html">Privacy Policy</a></li>
+            <li><a href="terms.html">Terms of Use</a></li>
+            <li><a href="disclosure.html">Disclosure</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Contact</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="tel:+18885551234">+1 (888) 555-1234</a></li>
+            <li><a href="mailto:hello@agentmessengers.com">hello@agentmessengers.com</a></li>
+            <li>1355 Market Street, Suite 420<br>San Francisco, CA 94103</li>
+          </ul>
+          <div class="footer-social mt-3">
+            <a href="https://www.facebook.com" aria-label="Facebook"><i class="fa-brands fa-facebook-f"></i></a>
+            <a href="https://www.twitter.com" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+            <a href="https://www.instagram.com" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+            <a href="https://www.linkedin.com" aria-label="LinkedIn"><i class="fa-brands fa-linkedin-in"></i></a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom text-center text-md-start mt-4">
+        © 2025 Agent Messengers. All Rights Reserved.
+      </div>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+  <script src="js/script.js"></script>
+</body>
+</html>

--- a/agentmessengers.com/reviews.html
+++ b/agentmessengers.com/reviews.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Customer Reviews &amp; Case Studies | Agent Messengers</title>
+  <meta name="description" content="See how insurance and advisory firms use Agent Messengers to accelerate compliant communications and delight regulators.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700&family=Montserrat:wght@600;700;800&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuU8Q0Kw5y7FZ5Fk5clU61M0W6Nqd53Y2xZC2Y1Qd5kZw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">
+        Agent Messengers
+        <span>AI-managed outreach for regulated teams</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="mainNav">
+        <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
+          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="services.html" id="servicesDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Services</a>
+            <ul class="dropdown-menu" aria-labelledby="servicesDropdown">
+              <li><a class="dropdown-item" href="services.html#essentials">Essentials Suite</a></li>
+              <li><a class="dropdown-item" href="services.html#compliance">Compliance Plus</a></li>
+              <li><a class="dropdown-item" href="services.html#enterprise">Global Enterprise</a></li>
+            </ul>
+          </li>
+          <li class="nav-item"><a class="nav-link" href="blog.html">Blog</a></li>
+          <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
+          <li class="nav-item"><a class="nav-link active" href="reviews.html">Reviews</a></li>
+          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+          <li class="nav-item"><a class="btn btn-link login-link" href="https://agentmessengers.com/login">Login</a></li>
+          <li class="nav-item"><a class="btn btn-primary" href="demo.html">Request a Demo</a></li>
+        </ul>
+        <div class="theme-toggle">
+          <i class="fa-regular fa-sun"></i>
+          <div class="form-check form-switch m-0">
+            <input class="form-check-input" type="checkbox" role="switch" id="themeSwitch" aria-label="Toggle dark mode">
+          </div>
+          <i class="fa-regular fa-moon"></i>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main>
+    <section class="article-hero">
+      <div class="container text-white">
+        <h1 class="text-white">Reviews from compliance and distribution leaders</h1>
+        <p class="lead text-white-50">Discover how Agent Messengers drives faster launches, higher engagement, and confident regulators.</p>
+      </div>
+    </section>
+
+    <section class="article-content">
+      <div class="container">
+        <div class="row g-4">
+          <div class="col-lg-6">
+            <div class="case-card h-100 p-4">
+              <img src="images/case-insurance.svg" alt="ShieldLine Insurance case study" class="img-fluid mb-3">
+              <h2>ShieldLine Insurance cuts approval time by 78%</h2>
+              <p class="text-muted-custom">Before Agent Messengers, ShieldLine’s compliance team juggled email threads and spreadsheets. Now every asset flows through AI-guided playbooks with crystal-clear audit trails.</p>
+              <ul class="list-unstyled d-grid gap-2 mb-3">
+                <li><i class="fa-solid fa-circle-check text-success"></i> Reduced regulator follow-up requests by 60%</li>
+                <li><i class="fa-solid fa-circle-check text-success"></i> Increased bilingual agent participation by 2.3x</li>
+                <li><i class="fa-solid fa-circle-check text-success"></i> Maintained 100% disclosure coverage across states</li>
+              </ul>
+              <blockquote class="mb-3">“Our regulators called the audit trail ‘best-in-class.’ We can finally launch campaigns in days, not weeks.” — <strong>Linh Nguyen, CCO</strong></blockquote>
+              <a href="demo.html" class="btn btn-primary">Recreate these results</a>
+            </div>
+          </div>
+          <div class="col-lg-6">
+            <div class="case-card h-100 p-4">
+              <h2>HarborPoint Advisory boosts client retention 14%</h2>
+              <p class="text-muted-custom">HarborPoint rolled Agent Messengers out to 1,200 advisors to unify customer outreach after regulatory changes. Personalized microbriefings now reach clients 48 hours sooner.</p>
+              <ul class="list-unstyled d-grid gap-2 mb-3">
+                <li><i class="fa-solid fa-circle-check text-success"></i> Automated 85% of disclosure insertions</li>
+                <li><i class="fa-solid fa-circle-check text-success"></i> 96% advisor adoption within the first quarter</li>
+                <li><i class="fa-solid fa-circle-check text-success"></i> Voice localization in four languages</li>
+              </ul>
+              <blockquote class="mb-3">“Our advisors appreciate how approachable compliance feels now. They have clear guidance without losing their authentic voice.” — <strong>Diego Álvarez, VP Distribution</strong></blockquote>
+              <a href="services.html" class="btn btn-secondary-custom">Explore our plans</a>
+            </div>
+          </div>
+          <div class="col-lg-12">
+            <div class="plan-card p-4">
+              <h2 class="mb-3">Voice of the customer</h2>
+              <div class="row g-4">
+                <div class="col-md-4">
+                  <p class="fw-bold mb-1">Ava Thompson, MutualSure</p>
+                  <p class="small text-muted-custom">Head of Policyholder Experience</p>
+                  <p>“We no longer dread regulatory bulletins. Agent Messengers assembles the right mix of SMS, email, and portal updates automatically.”</p>
+                </div>
+                <div class="col-md-4">
+                  <p class="fw-bold mb-1">Grace Patel, NorthBridge Wealth</p>
+                  <p class="small text-muted-custom">Chief Compliance Strategist</p>
+                  <p>“The transparency is unmatched. Every revision has context, so advisors feel supported rather than policed.”</p>
+                </div>
+                <div class="col-md-4">
+                  <p class="fw-bold mb-1">Marcus Reid, Beacon MGA</p>
+                  <p class="small text-muted-custom">Managing Director</p>
+                  <p>“Localization was chaos until now. We deliver culturally precise messaging across five markets with confidence.”</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="row gy-4">
+        <div class="col-md-4">
+          <div class="footer-brand">Agent Messengers</div>
+          <p class="footer-tagline">Empowering regulated teams to deliver compliant conversations at scale.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="d-inline-flex align-items-center gap-2">
+            Powered by <span class="fw-semibold">Netshow.AI</span>
+            <i class="fa-solid fa-arrow-up-right-from-square"></i>
+          </a>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Quick Links</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About Us</a></li>
+            <li><a href="services.html">Services</a></li>
+            <li><a href="products.html">Products</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Resources</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="blog.html">Blog</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="reviews.html">Reviews</a></li>
+            <li><a href="demo.html">Demo</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Legal</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="privacy.html">Privacy Policy</a></li>
+            <li><a href="terms.html">Terms of Use</a></li>
+            <li><a href="disclosure.html">Disclosure</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Contact</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="tel:+18885551234">+1 (888) 555-1234</a></li>
+            <li><a href="mailto:hello@agentmessengers.com">hello@agentmessengers.com</a></li>
+            <li>1355 Market Street, Suite 420<br>San Francisco, CA 94103</li>
+          </ul>
+          <div class="footer-social mt-3">
+            <a href="https://www.facebook.com" aria-label="Facebook"><i class="fa-brands fa-facebook-f"></i></a>
+            <a href="https://www.twitter.com" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+            <a href="https://www.instagram.com" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+            <a href="https://www.linkedin.com" aria-label="LinkedIn"><i class="fa-brands fa-linkedin-in"></i></a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom text-center text-md-start mt-4">
+        © 2025 Agent Messengers. All Rights Reserved.
+      </div>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+  <script src="js/script.js"></script>
+</body>
+</html>

--- a/agentmessengers.com/services.html
+++ b/agentmessengers.com/services.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Services &amp; Pricing | Agent Messengers</title>
+  <meta name="description" content="Compare Agent Messengers subscription tiers and find the right plan for orchestrating compliant, AI-powered communications across your advisory network.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700&family=Montserrat:wght@600;700;800&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuU8Q0Kw5y7FZ5Fk5clU61M0W6Nqd53Y2xZC2Y1Qd5kZw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">
+        Agent Messengers
+        <span>AI-managed outreach for regulated teams</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="mainNav">
+        <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
+          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle active" href="services.html" id="servicesDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Services</a>
+            <ul class="dropdown-menu" aria-labelledby="servicesDropdown">
+              <li><a class="dropdown-item" href="#essentials">Essentials Suite</a></li>
+              <li><a class="dropdown-item" href="#compliance">Compliance Plus</a></li>
+              <li><a class="dropdown-item" href="#enterprise">Global Enterprise</a></li>
+            </ul>
+          </li>
+          <li class="nav-item"><a class="nav-link" href="blog.html">Blog</a></li>
+          <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
+          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+          <li class="nav-item"><a class="btn btn-link login-link" href="https://agentmessengers.com/login">Login</a></li>
+          <li class="nav-item"><a class="btn btn-primary" href="demo.html">Request a Demo</a></li>
+        </ul>
+        <div class="theme-toggle">
+          <i class="fa-regular fa-sun"></i>
+          <div class="form-check form-switch m-0">
+            <input class="form-check-input" type="checkbox" role="switch" id="themeSwitch" aria-label="Toggle dark mode">
+          </div>
+          <i class="fa-regular fa-moon"></i>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main>
+    <section class="hero-section">
+      <div class="container">
+        <div class="row align-items-center gy-4">
+          <div class="col-lg-8 text-white">
+            <h1 class="text-white">Plans engineered for compliance leaders and field teams</h1>
+            <p class="lead text-white-75">Choose the subscription that meets your review throughput, localization needs, and integration roadmap.</p>
+          </div>
+          <div class="col-lg-4 text-lg-end text-center text-white">
+            <div class="stat-chip bg-white text-dark d-inline-flex"><i class="fa-solid fa-chart-line text-primary"></i> Avg. 5x faster launches</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <div class="container">
+        <div class="row g-4">
+          <div class="col-md-4" id="essentials">
+            <div class="plan-card h-100">
+              <div class="icon-circle"><i class="fa-solid fa-seedling"></i></div>
+              <h3>Essentials Suite</h3>
+              <p class="text-muted-custom">For regional teams ready to automate intake, approvals, and channel-ready assets.</p>
+              <h4 class="display-6 fw-bold">$1,800<span class="fs-6 fw-normal">/month</span></h4>
+              <ul class="list-unstyled d-grid gap-2 mt-3">
+                <li><i class="fa-solid fa-check text-success"></i> Automated document ingestion &amp; tagging</li>
+                <li><i class="fa-solid fa-check text-success"></i> Two outbound channels (email + SMS)</li>
+                <li><i class="fa-solid fa-check text-success"></i> Regional compliance rule packs</li>
+                <li><i class="fa-solid fa-check text-success"></i> Up to 50 active seats</li>
+              </ul>
+              <a href="demo.html" class="btn btn-primary mt-3">Start with demo</a>
+            </div>
+          </div>
+          <div class="col-md-4" id="compliance">
+            <div class="plan-card h-100 border border-3 border-warning">
+              <div class="icon-circle"><i class="fa-solid fa-shield"></i></div>
+              <h3>Compliance Plus</h3>
+              <p class="text-muted-custom">For national carriers orchestrating multi-state releases with advanced localization.</p>
+              <h4 class="display-6 fw-bold">$3,600<span class="fs-6 fw-normal">/month</span></h4>
+              <ul class="list-unstyled d-grid gap-2 mt-3">
+                <li><i class="fa-solid fa-check text-success"></i> Unlimited playbooks &amp; asset types</li>
+                <li><i class="fa-solid fa-check text-success"></i> Multilingual co-pilots in 12 languages</li>
+                <li><i class="fa-solid fa-check text-success"></i> Automated audit trails &amp; regulator packets</li>
+                <li><i class="fa-solid fa-check text-success"></i> Dedicated compliance success manager</li>
+              </ul>
+              <a href="demo.html" class="btn btn-secondary-custom mt-3">Talk to sales</a>
+            </div>
+          </div>
+          <div class="col-md-4" id="enterprise">
+            <div class="plan-card h-100">
+              <div class="icon-circle"><i class="fa-solid fa-earth-americas"></i></div>
+              <h3>Global Enterprise</h3>
+              <p class="text-muted-custom">For multi-brand groups coordinating global launches, bespoke integrations, and advanced security.</p>
+              <h4 class="display-6 fw-bold">Custom</h4>
+              <ul class="list-unstyled d-grid gap-2 mt-3">
+                <li><i class="fa-solid fa-check text-success"></i> Private cloud deployment options</li>
+                <li><i class="fa-solid fa-check text-success"></i> Cross-border privacy attestation workflows</li>
+                <li><i class="fa-solid fa-check text-success"></i> Dedicated AI tuning &amp; scenario modeling</li>
+                <li><i class="fa-solid fa-check text-success"></i> Unlimited seats &amp; channel connectors</li>
+              </ul>
+              <a href="contact.html" class="btn btn-primary mt-3">Contact us</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="bg-surface">
+      <div class="container">
+        <div class="row justify-content-center text-center mb-4">
+          <div class="col-lg-8">
+            <h2>Compare what is included</h2>
+            <p class="text-muted-custom">Every plan includes security-first infrastructure, SOC 2 controls, and 24/5 live support.</p>
+          </div>
+        </div>
+        <div class="table-responsive">
+          <table class="table table-custom align-middle text-start">
+            <thead>
+              <tr>
+                <th scope="col">Capabilities</th>
+                <th scope="col">Essentials Suite</th>
+                <th scope="col">Compliance Plus</th>
+                <th scope="col">Global Enterprise</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">Message approvals per month</th>
+                <td>Up to 250</td>
+                <td>Up to 1,000</td>
+                <td>Unlimited</td>
+              </tr>
+              <tr>
+                <th scope="row">Supported channels</th>
+                <td>Email, SMS</td>
+                <td>Email, SMS, voice, CRM journeys</td>
+                <td>All plus contact center integrations</td>
+              </tr>
+              <tr>
+                <th scope="row">Localization coverage</th>
+                <td>English &amp; Spanish</td>
+                <td>12 languages with cultural QA</td>
+                <td>Global with in-country linguists</td>
+              </tr>
+              <tr>
+                <th scope="row">Regulatory monitoring</th>
+                <td>State DOI alerts</td>
+                <td>State + federal + FINRA bulletins</td>
+                <td>All plus custom regulator feeds</td>
+              </tr>
+              <tr>
+                <th scope="row">Integrations</th>
+                <td>Salesforce + Microsoft Dynamics</td>
+                <td>All Essentials plus Guidewire &amp; Vlocity</td>
+                <td>Custom middleware &amp; data lake sync</td>
+              </tr>
+              <tr>
+                <th scope="row">Training &amp; onboarding</th>
+                <td>Self-paced launch kit</td>
+                <td>Hands-on configuration workshops</td>
+                <td>Embedded transformation squad</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <div class="container">
+        <div class="row align-items-center gy-4">
+          <div class="col-lg-7">
+            <h2>Need help selecting a plan?</h2>
+            <p class="text-muted-custom">Our compliance strategists will review your current communication cycle times, regulator expectations, and data privacy requirements.</p>
+          </div>
+          <div class="col-lg-5 text-lg-end text-center">
+            <a href="demo.html" class="btn btn-primary me-3">Request a guided tour</a>
+            <a href="contact.html" class="btn btn-secondary-custom">Talk to compliance</a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="row gy-4">
+        <div class="col-md-4">
+          <div class="footer-brand">Agent Messengers</div>
+          <p class="footer-tagline">Empowering regulated teams to deliver compliant conversations at scale.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="d-inline-flex align-items-center gap-2">
+            Powered by <span class="fw-semibold">Netshow.AI</span>
+            <i class="fa-solid fa-arrow-up-right-from-square"></i>
+          </a>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Quick Links</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About Us</a></li>
+            <li><a href="services.html">Services</a></li>
+            <li><a href="products.html">Products</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Resources</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="blog.html">Blog</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="reviews.html">Reviews</a></li>
+            <li><a href="demo.html">Demo</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Legal</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="privacy.html">Privacy Policy</a></li>
+            <li><a href="terms.html">Terms of Use</a></li>
+            <li><a href="disclosure.html">Disclosure</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Contact</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="tel:+18885551234">+1 (888) 555-1234</a></li>
+            <li><a href="mailto:hello@agentmessengers.com">hello@agentmessengers.com</a></li>
+            <li>1355 Market Street, Suite 420<br>San Francisco, CA 94103</li>
+          </ul>
+          <div class="footer-social mt-3">
+            <a href="https://www.facebook.com" aria-label="Facebook"><i class="fa-brands fa-facebook-f"></i></a>
+            <a href="https://www.twitter.com" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+            <a href="https://www.instagram.com" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+            <a href="https://www.linkedin.com" aria-label="LinkedIn"><i class="fa-brands fa-linkedin-in"></i></a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom text-center text-md-start mt-4">
+        © 2025 Agent Messengers. All Rights Reserved.
+      </div>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+  <script src="js/script.js"></script>
+</body>
+</html>

--- a/agentmessengers.com/terms.html
+++ b/agentmessengers.com/terms.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Terms of Use | Agent Messengers</title>
+  <meta name="description" content="Review the terms governing access to the Agent Messengers website and platform services.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700&family=Montserrat:wght@600;700;800&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuU8Q0Kw5y7FZ5Fk5clU61M0W6Nqd53Y2xZC2Y1Qd5kZw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">
+        Agent Messengers
+        <span>AI-managed outreach for regulated teams</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="mainNav">
+        <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
+          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="services.html" id="servicesDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Services</a>
+            <ul class="dropdown-menu" aria-labelledby="servicesDropdown">
+              <li><a class="dropdown-item" href="services.html#essentials">Essentials Suite</a></li>
+              <li><a class="dropdown-item" href="services.html#compliance">Compliance Plus</a></li>
+              <li><a class="dropdown-item" href="services.html#enterprise">Global Enterprise</a></li>
+            </ul>
+          </li>
+          <li class="nav-item"><a class="nav-link" href="blog.html">Blog</a></li>
+          <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
+          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+          <li class="nav-item"><a class="btn btn-link login-link" href="https://agentmessengers.com/login">Login</a></li>
+          <li class="nav-item"><a class="btn btn-primary" href="demo.html">Request a Demo</a></li>
+        </ul>
+        <div class="theme-toggle">
+          <i class="fa-regular fa-sun"></i>
+          <div class="form-check form-switch m-0">
+            <input class="form-check-input" type="checkbox" role="switch" id="themeSwitch" aria-label="Toggle dark mode">
+          </div>
+          <i class="fa-regular fa-moon"></i>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main>
+    <section class="article-hero">
+      <div class="container text-white">
+        <h1 class="text-white">Terms of Use</h1>
+        <p class="lead text-white-50">Effective January 1, 2025</p>
+      </div>
+    </section>
+
+    <section class="article-content">
+      <div class="container">
+        <div class="row justify-content-center">
+          <div class="col-lg-9">
+            <h2>1. Acceptance of terms</h2>
+            <p>By accessing agentmessengers.com or using the Agent Messengers platform, you agree to these Terms of Use. If you are acting on behalf of an organization, you confirm that you have authority to bind that organization.</p>
+
+            <h2>2. Use of services</h2>
+            <p>You agree to use the platform in accordance with applicable laws and regulatory obligations. You will not reverse engineer, interfere with, or misuse the services. Authorized users must keep login credentials secure.</p>
+
+            <h2>3. Customer content</h2>
+            <p>You retain ownership of content submitted to the platform. You grant Agent Messengers a license to host, process, and transmit that content solely to deliver services. You are responsible for obtaining any permissions required to process personal or regulated data.</p>
+
+            <h2>4. Intellectual property</h2>
+            <p>All Agent Messengers trademarks, software, and documentation are owned by us or our licensors. Except as expressly permitted, you may not reproduce or create derivative works from our intellectual property.</p>
+
+            <h2>5. Confidentiality</h2>
+            <p>Each party will protect confidential information disclosed under these Terms. Confidential information includes product roadmaps, customer data, and pricing that is not public knowledge.</p>
+
+            <h2>6. Payment terms</h2>
+            <p>Subscription fees are invoiced according to the order form and are non-refundable except as required by law. Late payments may incur interest at the lower of 1.5% per month or the maximum allowed by law.</p>
+
+            <h2>7. Warranties and disclaimers</h2>
+            <p>We warrant that the platform will perform materially in accordance with documentation. Except for this limited warranty, the services are provided “as is.” We disclaim all other warranties, including implied warranties of merchantability or fitness for a particular purpose.</p>
+
+            <h2>8. Limitation of liability</h2>
+            <p>To the maximum extent permitted by law, neither party is liable for indirect, consequential, or punitive damages. Our total liability arising from these Terms will not exceed fees paid to Agent Messengers during the twelve months preceding the claim.</p>
+
+            <h2>9. Indemnification</h2>
+            <p>You agree to indemnify and hold Agent Messengers harmless from third-party claims arising from your misuse of the services or violation of these Terms. We will defend you from third-party claims alleging the services infringe intellectual property rights, subject to customary limitations.</p>
+
+            <h2>10. Governing law</h2>
+            <p>These Terms are governed by the laws of the State of California, excluding conflict of law principles. Any dispute will be resolved in the state or federal courts located in San Francisco County, California.</p>
+
+            <h2>11. Changes</h2>
+            <p>We may update these Terms from time to time. Continued use of the services after updates constitutes acceptance of the revised Terms.</p>
+
+            <h2>12. Contact</h2>
+            <p>Questions can be directed to legal@agentmessengers.com.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="row gy-4">
+        <div class="col-md-4">
+          <div class="footer-brand">Agent Messengers</div>
+          <p class="footer-tagline">Empowering regulated teams to deliver compliant conversations at scale.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="d-inline-flex align-items-center gap-2">
+            Powered by <span class="fw-semibold">Netshow.AI</span>
+            <i class="fa-solid fa-arrow-up-right-from-square"></i>
+          </a>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Quick Links</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="index.html">Home</a></li>
+            <li><a href="about.html">About Us</a></li>
+            <li><a href="services.html">Services</a></li>
+            <li><a href="products.html">Products</a></li>
+            <li><a href="contact.html">Contact</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Resources</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="blog.html">Blog</a></li>
+            <li><a href="faq.html">FAQ</a></li>
+            <li><a href="reviews.html">Reviews</a></li>
+            <li><a href="demo.html">Demo</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Legal</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="privacy.html">Privacy Policy</a></li>
+            <li><a href="terms.html">Terms of Use</a></li>
+            <li><a href="disclosure.html">Disclosure</a></li>
+          </ul>
+        </div>
+        <div class="col-md-2">
+          <div class="footer-heading">Contact</div>
+          <ul class="list-unstyled d-grid gap-2">
+            <li><a href="tel:+18885551234">+1 (888) 555-1234</a></li>
+            <li><a href="mailto:hello@agentmessengers.com">hello@agentmessengers.com</a></li>
+            <li>1355 Market Street, Suite 420<br>San Francisco, CA 94103</li>
+          </ul>
+          <div class="footer-social mt-3">
+            <a href="https://www.facebook.com" aria-label="Facebook"><i class="fa-brands fa-facebook-f"></i></a>
+            <a href="https://www.twitter.com" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
+            <a href="https://www.instagram.com" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
+            <a href="https://www.linkedin.com" aria-label="LinkedIn"><i class="fa-brands fa-linkedin-in"></i></a>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom text-center text-md-start mt-4">
+        © 2025 Agent Messengers. All Rights Reserved.
+      </div>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+  <script src="js/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build a new Agent Messengers marketing site with hero lead capture, feature highlights, testimonials, and media logos
- add supporting pages for services, products, demo workflow, articles, reviews, FAQ, and legal policies tailored to regulated communications teams
- implement custom Bootstrap styling, reusable imagery, and a JavaScript-powered theme toggle with form feedback handling

## Testing
- Not run (static site)

------
https://chatgpt.com/codex/tasks/task_b_68ca87aec484832aa9bfad99638227c4