### PR TITLE
Add Agent Web Applications website

### DIFF
--- a/agentwebapplications.com/about.html
+++ b/agentwebapplications.com/about.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>About Agent Web Applications | Mission, Story, Team</title>
+  <meta name="description" content="Discover the mission, founding story, and leadership team behind Agent Web Applications, the studio building compliance-ready AI agent web experiences.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+  <script defer src="js/script.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <div id="login" class="sr-only" aria-hidden="true">Client portal access for subscribers is handled through our secure workspace.</div>
+  <header class="site-header" role="banner">
+    <div class="container nav-wrapper">
+      <a class="logo" href="index.html" aria-label="Agent Web Applications home">
+        <svg aria-hidden="true" viewBox="0 0 48 48">
+          <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+          <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+          <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+        </svg>
+        <span>Agent Web Applications</span>
+      </a>
+      <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+      <nav class="primary-nav" id="primary-navigation" aria-label="Primary navigation">
+        <ul class="nav-list">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html" aria-current="page">About</a></li>
+          <li class="nav-dropdown">
+            <button class="dropdown-toggle" type="button" data-dropdown-toggle aria-expanded="false" aria-haspopup="true">
+              Services
+              <svg aria-hidden="true" viewBox="0 0 16 16">
+                <path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+            <ul class="dropdown-menu" data-dropdown-menu>
+              <li><a href="services.html#tier-basic">Launch Pad (Basic)</a></li>
+              <li><a href="services.html#tier-pro">Workflow Studio (Pro)</a></li>
+              <li><a href="services.html#tier-enterprise">Co-Pilot Cloud (Enterprise)</a></li>
+            </ul>
+          </li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <div class="nav-actions">
+        <a class="btn btn-secondary" href="#login">Login</a>
+        <a class="btn btn-primary" href="demo.html">Request a Demo</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
+          <span aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img">
+              <path d="M12 4a1 1 0 0 1 1 1v2.06a1 1 0 0 1-2 0V5a1 1 0 0 1 1-1zm6.36 3.64a1 1 0 0 1 0 1.41l-1.46 1.46a1 1 0 0 1-1.41-1.41l1.46-1.46a1 1 0 0 1 1.41 0zM19 11h2a1 1 0 0 1 0 2h-2a1 1 0 0 1 0-2zm-7 7a1 1 0 0 1 1-1h2.06a1 1 0 0 1 0 2H13a1 1 0 0 1-1-1zm-5.95-1.05a1 1 0 0 1 1.41 0l1.46 1.46a1 1 0 0 1-1.41 1.41l-1.46-1.46a1 1 0 0 1 0-1.41zM5 11a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2h2zm1.05-5.95a1 1 0 0 1 1.41 0l1.46 1.46A1 1 0 0 1 7.51 7.92L6.05 6.46a1 1 0 0 1 0-1.41z" fill="currentColor"></path>
+              <circle cx="12" cy="12" r="3" fill="currentColor"></circle>
+            </svg>
+          </span>
+          <span data-theme-label>Switch to dark mode</span>
+        </button>
+      </div>
+    </div>
+  </header>
+  <main id="main">
+    <section class="section">
+      <div class="container">
+        <div class="section-header">
+          <h1>We exist to make regulated AI usable</h1>
+          <p>Agent Web Applications was founded to bridge the gap between the promise of autonomous agents and the realities of regulated, high-stakes operations.</p>
+        </div>
+        <div class="article" style="gap:2rem;">
+          <section aria-labelledby="mission-heading">
+            <h2 id="mission-heading">Mission</h2>
+            <p>Our mission is to build trustworthy agent-powered web experiences that give operations teams superpowers without putting compliance, safety, or customers at risk. We believe the organizations that win with AI will be those that combine domain expertise with responsible design.</p>
+          </section>
+          <section aria-labelledby="story-heading">
+            <h2 id="story-heading">Our Story</h2>
+            <p>In 2022, a group of product strategists, machine learning researchers, and compliance officers joined forces after seeing the same pattern: AI prototypes stalled during legal review and agents never reached production. We formed Agent Web Applications to deliver a new kind of build partner—one that owns the full journey from governance workshops to continuous monitoring.</p>
+            <p>Today we run distributed playbooks across San Francisco, Austin, and Lisbon, supporting clients in healthcare, logistics, energy, and public sector agencies. Every engagement begins with a “policy-first design sprint” that ensures guardrails are baked into code, not bolted on.</p>
+          </section>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="team">
+      <div class="container">
+        <div class="section-header">
+          <h2>Leadership Team</h2>
+          <p>Our cross-functional team unites regulated industry veterans with builders who know how to ship resilient AI products.</p>
+        </div>
+        <div class="cards-grid">
+          <article class="profile-card">
+            <img src="images/team-ava-1.svg" alt="Portrait of CEO Taryn Blake">
+            <h3>Taryn Blake</h3>
+            <p>Chief Executive Officer</p>
+            <p>Taryn led platform strategy at two Fortune 100 healthcare systems before founding Agent Web Applications. She champions measurable outcomes and transparent governance.</p>
+          </article>
+          <article class="profile-card">
+            <img src="images/team-ava-2.svg" alt="Portrait of CTO Dev Malik">
+            <h3>Dev Malik</h3>
+            <p>Chief Technology Officer</p>
+            <p>Dev designed large-scale agent orchestration frameworks at top cloud providers. He oversees the agent blueprint library and the security architecture.</p>
+          </article>
+          <article class="profile-card">
+            <img src="images/team-ava-3.svg" alt="Portrait of COO Lila Anders">
+            <h3>Lila Anders</h3>
+            <p>Chief Operations Officer</p>
+            <p>Lila previously managed compliance transformation programs in aerospace manufacturing. She ensures every engagement meets regulatory obligations.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="values">
+      <div class="container">
+        <div class="section-header">
+          <h2>Values that guide our builds</h2>
+          <p>We codified values that keep every project aligned to the needs of end users, regulators, and our partners.</p>
+        </div>
+        <div class="values-list">
+          <article class="value-card">
+            <h3>Policy-first design</h3>
+            <p>We start with the rules, constraints, and human workflows so our agent interfaces earn trust faster.</p>
+          </article>
+          <article class="value-card">
+            <h3>Transparent instrumentation</h3>
+            <p>Every agent action is observable, auditable, and explainable. No black boxes, only shared visibility.</p>
+          </article>
+          <article class="value-card">
+            <h3>Co-creation with operators</h3>
+            <p>We design side-by-side with the people who will use the tools, validating the experience before a single line of code ships.</p>
+          </article>
+          <article class="value-card">
+            <h3>Iteration over assumption</h3>
+            <p>We pair measurement frameworks with rapid release cadences so agent behavior improves every week.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-brand">
+          <a class="logo" href="index.html">
+            <svg aria-hidden="true" viewBox="0 0 48 48">
+              <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+              <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+              <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+            </svg>
+            <span>Agent Web Applications</span>
+          </a>
+          <p>We design, govern, and scale AI agent web apps for regulated teams that need measurable outcomes.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="btn btn-ghost">Netshow.AI</a>
+        </div>
+        <div>
+          <h3 class="sr-only">Quick Links</h3>
+          <div class="footer-links">
+            <a href="index.html">Home</a>
+            <a href="about.html" aria-current="page">About</a>
+            <a href="services.html">Services</a>
+            <a href="blog.html">Blog</a>
+            <a href="faq.html">FAQ</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Legal Links</h3>
+          <div class="footer-links">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="disclosure.html">Disclosure</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Contact Information</h3>
+          <div class="footer-links">
+            <span>99 Market Street, Suite 540<br>San Francisco, CA 94105</span>
+            <a href="tel:+14155550123">+1 (415) 555-0123</a>
+            <a href="mailto:hello@agentwebapplications.com">hello@agentwebapplications.com</a>
+            <div class="social-links" aria-label="Social media">
+              <a href="https://www.facebook.com" aria-label="Facebook">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M14 8h2V5h-2c-2.2 0-4 1.8-4 4v2H8v3h2v7h3v-7h3l1-3h-4V9c0-.6.4-1 1-1z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.twitter.com" aria-label="X">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4 4l7.5 7.5L4 20h3.5l5.2-6 5.1 6H20l-7.4-8L20 4h-3.4l-4.7 5.5L7.2 4z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.instagram.com" aria-label="Instagram">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <rect x="3" y="3" width="18" height="18" rx="5" ry="5" fill="none" stroke="currentColor" stroke-width="2"></rect>
+                  <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="2"></circle>
+                  <circle cx="17" cy="7" r="1.5" fill="currentColor"></circle>
+                </svg>
+              </a>
+              <a href="https://www.linkedin.com" aria-label="LinkedIn">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4.98 3.5a2 2 0 1 1 0 4 2 2 0 0 1 0-4zM4 8.75h2.1V20H4zM9.25 8.75H11.3v1.54h.03c.29-.55 1-1.13 2.06-1.13 2.2 0 2.6 1.45 2.6 3.33V20h-2.1v-6c0-1.43-.03-3.26-1.99-3.26-1.99 0-2.3 1.55-2.3 3.15V20H9.25z" fill="currentColor"></path>
+                </svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© 2025 Agent Web Applications. All Rights Reserved.</span>
+        <span>Built for intelligent orchestration of web-based AI agents.</span>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/agentwebapplications.com/blog-article-1.html
+++ b/agentwebapplications.com/blog-article-1.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Five pillars of trustworthy agent governance | Agent Web Applications</title>
+  <meta name="description" content="Learn the five governance pillars Agent Web Applications uses to make AI agent web apps safe for regulated industries.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+  <script defer src="js/script.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <div id="login" class="sr-only" aria-hidden="true">Client portal access for subscribers is handled through our secure workspace.</div>
+  <header class="site-header" role="banner">
+    <div class="container nav-wrapper">
+      <a class="logo" href="index.html" aria-label="Agent Web Applications home">
+        <svg aria-hidden="true" viewBox="0 0 48 48">
+          <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+          <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+          <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+        </svg>
+        <span>Agent Web Applications</span>
+      </a>
+      <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+      <nav class="primary-nav" id="primary-navigation" aria-label="Primary navigation">
+        <ul class="nav-list">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li class="nav-dropdown">
+            <button class="dropdown-toggle" type="button" data-dropdown-toggle aria-expanded="false" aria-haspopup="true">
+              Services
+              <svg aria-hidden="true" viewBox="0 0 16 16">
+                <path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+            <ul class="dropdown-menu" data-dropdown-menu>
+              <li><a href="services.html#tier-basic">Launch Pad (Basic)</a></li>
+              <li><a href="services.html#tier-pro">Workflow Studio (Pro)</a></li>
+              <li><a href="services.html#tier-enterprise">Co-Pilot Cloud (Enterprise)</a></li>
+            </ul>
+          </li>
+          <li><a href="blog.html" aria-current="page">Blog</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <div class="nav-actions">
+        <a class="btn btn-secondary" href="#login">Login</a>
+        <a class="btn btn-primary" href="demo.html">Request a Demo</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
+          <span aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img">
+              <path d="M12 4a1 1 0 0 1 1 1v2.06a1 1 0 0 1-2 0V5a1 1 0 0 1 1-1zm6.36 3.64a1 1 0 0 1 0 1.41l-1.46 1.46a1 1 0 0 1-1.41-1.41l1.46-1.46a1 1 0 0 1 1.41 0zM19 11h2a1 1 0 0 1 0 2h-2a1 1 0 0 1 0-2zm-7 7a1 1 0 0 1 1-1h2.06a1 1 0 0 1 0 2H13a1 1 0 0 1-1-1zm-5.95-1.05a1 1 0 0 1 1.41 0l1.46 1.46a1 1 0 0 1-1.41 1.41l-1.46-1.46a1 1 0 0 1 0-1.41zM5 11a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2h2zm1.05-5.95a1 1 0 0 1 1.41 0l1.46 1.46A1 1 0 0 1 7.51 7.92L6.05 6.46a1 1 0 0 1 0-1.41z" fill="currentColor"></path>
+              <circle cx="12" cy="12" r="3" fill="currentColor"></circle>
+            </svg>
+          </span>
+          <span data-theme-label>Switch to dark mode</span>
+        </button>
+      </div>
+    </div>
+  </header>
+  <main id="main" class="section">
+    <div class="container">
+      <article class="article">
+        <header>
+          <p class="blog-meta" style="gap:1.5rem;">
+            <span>January 22, 2025</span>
+            <span class="tag">
+              <svg viewBox="0 0 16 16" aria-hidden="true">
+                <path d="M7 1l6 6-6 6H1V7z" fill="currentColor"></path>
+              </svg>
+              Governance
+            </span>
+          </p>
+          <h1>Five pillars of trustworthy agent governance</h1>
+          <p>AI agents can deliver extraordinary efficiency, but only when organizations take governance as seriously as they take experimentation. Over the past three years, the Agent Web Applications team has supported heavily regulated clients around the world. These five pillars are the backbone of every launch.</p>
+        </header>
+
+        <h2>1. Policy-first discovery</h2>
+        <p>Before we write a single line of code, we co-create a detailed policy map with legal, compliance, and frontline operators. This includes documenting applicable regulations, consent requirements, and data residency rules. By capturing these constraints up front, we prevent last-minute surprises.</p>
+        <ul>
+          <li>Stakeholder interviews across compliance, IT, and frontline teams</li>
+          <li>Regulatory matrix outlining approvals, retention, and disclosure rules</li>
+          <li>Risk heatmap to prioritize mitigations and manual controls</li>
+        </ul>
+
+        <h2>2. Guardrail design alongside UX</h2>
+        <p>We design guardrails and user flows simultaneously. An agent experience is only trustworthy when policy reminders, escalation buttons, and audit notices appear naturally inside the workflow. Our design library includes components for human approval, secondary verification, and redaction prompts.</p>
+
+        <h2>3. Transparent observability</h2>
+        <p>Trust hinges on visibility. We instrument every agent action with structured logs, reason traces, and reviewer notes. Leadership dashboards highlight the metrics that matter—resolution time, exception rate, compliance nudges—and allow teams to drill into specific sessions for investigation.</p>
+        <blockquote>“Observability is the difference between an AI experiment and an AI program. If the humans in charge cannot see inside the agent, they will eventually switch it off.”</blockquote>
+
+        <h2>4. Human-in-the-loop accountability</h2>
+        <p>Autonomy should not mean isolation. Every agent web app we deploy includes escalation ladders, live collaboration surfaces, and automatic alerts to subject matter experts. Agents handle the busy work while humans make the decisions that require judgment and empathy.</p>
+
+        <h2>5. Iteration with audit discipline</h2>
+        <p>Governance does not end at launch. We schedule recurring policy reviews, maintain versioned prompt libraries, and generate audit-ready change logs. Continuous improvement is only safe when each iteration is documented and reversible.</p>
+        <ul>
+          <li>Quarterly compliance retrospectives to evaluate guardrails</li>
+          <li>Shadow mode testing before expanding agent scope</li>
+          <li>Change management rituals with sign-off from accountable executives</li>
+        </ul>
+
+        <p>These pillars ensure that the Agent Programming Tool stack we assemble into web experiences remains compliant, reliable, and human-centric. If your organization is ready to operationalize AI agents, start by strengthening governance. The technology will follow.</p>
+      </article>
+    </div>
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-brand">
+          <a class="logo" href="index.html">
+            <svg aria-hidden="true" viewBox="0 0 48 48">
+              <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+              <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+              <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+            </svg>
+            <span>Agent Web Applications</span>
+          </a>
+          <p>We design, govern, and scale AI agent web apps for regulated teams that need measurable outcomes.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="btn btn-ghost">Netshow.AI</a>
+        </div>
+        <div>
+          <h3 class="sr-only">Quick Links</h3>
+          <div class="footer-links">
+            <a href="index.html">Home</a>
+            <a href="about.html">About</a>
+            <a href="services.html">Services</a>
+            <a href="blog.html" aria-current="page">Blog</a>
+            <a href="faq.html">FAQ</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Legal Links</h3>
+          <div class="footer-links">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="disclosure.html">Disclosure</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Contact Information</h3>
+          <div class="footer-links">
+            <span>99 Market Street, Suite 540<br>San Francisco, CA 94105</span>
+            <a href="tel:+14155550123">+1 (415) 555-0123</a>
+            <a href="mailto:hello@agentwebapplications.com">hello@agentwebapplications.com</a>
+            <div class="social-links" aria-label="Social media">
+              <a href="https://www.facebook.com" aria-label="Facebook">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M14 8h2V5h-2c-2.2 0-4 1.8-4 4v2H8v3h2v7h3v-7h3l1-3h-4V9c0-.6.4-1 1-1z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.twitter.com" aria-label="X">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4 4l7.5 7.5L4 20h3.5l5.2-6 5.1 6H20l-7.4-8L20 4h-3.4l-4.7 5.5L7.2 4z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.instagram.com" aria-label="Instagram">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <rect x="3" y="3" width="18" height="18" rx="5" ry="5" fill="none" stroke="currentColor" stroke-width="2"></rect>
+                  <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="2"></circle>
+                  <circle cx="17" cy="7" r="1.5" fill="currentColor"></circle>
+                </svg>
+              </a>
+              <a href="https://www.linkedin.com" aria-label="LinkedIn">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4.98 3.5a2 2 0 1 1 0 4 2 2 0 0 1 0-4zM4 8.75h2.1V20H4zM9.25 8.75H11.3v1.54h.03c.29-.55 1-1.13 2.06-1.13 2.2 0 2.6 1.45 2.6 3.33V20h-2.1v-6c0-1.43-.03-3.26-1.99-3.26-1.99 0-2.3 1.55-2.3 3.15V20H9.25z" fill="currentColor"></path>
+                </svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© 2025 Agent Web Applications. All Rights Reserved.</span>
+        <span>Built for intelligent orchestration of web-based AI agents.</span>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/agentwebapplications.com/blog-article-2.html
+++ b/agentwebapplications.com/blog-article-2.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Designing agent telemetry that teams actually use | Agent Web Applications</title>
+  <meta name="description" content="Discover the telemetry practices Agent Web Applications uses to make AI agent analytics actionable for frontline teams.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+  <script defer src="js/script.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <div id="login" class="sr-only" aria-hidden="true">Client portal access for subscribers is handled through our secure workspace.</div>
+  <header class="site-header" role="banner">
+    <div class="container nav-wrapper">
+      <a class="logo" href="index.html" aria-label="Agent Web Applications home">
+        <svg aria-hidden="true" viewBox="0 0 48 48">
+          <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+          <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+          <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+        </svg>
+        <span>Agent Web Applications</span>
+      </a>
+      <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+      <nav class="primary-nav" id="primary-navigation" aria-label="Primary navigation">
+        <ul class="nav-list">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li class="nav-dropdown">
+            <button class="dropdown-toggle" type="button" data-dropdown-toggle aria-expanded="false" aria-haspopup="true">
+              Services
+              <svg aria-hidden="true" viewBox="0 0 16 16">
+                <path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+            <ul class="dropdown-menu" data-dropdown-menu>
+              <li><a href="services.html#tier-basic">Launch Pad (Basic)</a></li>
+              <li><a href="services.html#tier-pro">Workflow Studio (Pro)</a></li>
+              <li><a href="services.html#tier-enterprise">Co-Pilot Cloud (Enterprise)</a></li>
+            </ul>
+          </li>
+          <li><a href="blog.html" aria-current="page">Blog</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <div class="nav-actions">
+        <a class="btn btn-secondary" href="#login">Login</a>
+        <a class="btn btn-primary" href="demo.html">Request a Demo</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
+          <span aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img">
+              <path d="M12 4a1 1 0 0 1 1 1v2.06a1 1 0 0 1-2 0V5a1 1 0 0 1 1-1zm6.36 3.64a1 1 0 0 1 0 1.41l-1.46 1.46a1 1 0 0 1-1.41-1.41l1.46-1.46a1 1 0 0 1 1.41 0zM19 11h2a1 1 0 0 1 0 2h-2a1 1 0 0 1 0-2zm-7 7a1 1 0 0 1 1-1h2.06a1 1 0 0 1 0 2H13a1 1 0 0 1-1-1zm-5.95-1.05a1 1 0 0 1 1.41 0l1.46 1.46a1 1 0 0 1-1.41 1.41l-1.46-1.46a1 1 0 0 1 0-1.41zM5 11a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2h2zm1.05-5.95a1 1 0 0 1 1.41 0l1.46 1.46A1 1 0 0 1 7.51 7.92L6.05 6.46a1 1 0 0 1 0-1.41z" fill="currentColor"></path>
+              <circle cx="12" cy="12" r="3" fill="currentColor"></circle>
+            </svg>
+          </span>
+          <span data-theme-label>Switch to dark mode</span>
+        </button>
+      </div>
+    </div>
+  </header>
+  <main id="main" class="section">
+    <div class="container">
+      <article class="article">
+        <header>
+          <p class="blog-meta" style="gap:1.5rem;">
+            <span>December 12, 2024</span>
+            <span class="tag">
+              <svg viewBox="0 0 16 16" aria-hidden="true">
+                <path d="M7 1l6 6-6 6H1V7z" fill="currentColor"></path>
+              </svg>
+              Observability
+            </span>
+          </p>
+          <h1>Designing agent telemetry that teams actually use</h1>
+          <p>Dashboards often fail not because the data is missing, but because the insights do not meet teams where they work. We build telemetry for agent web apps by focusing on human workflow first, then layering in metrics and alerting that reinforce great behavior.</p>
+        </header>
+
+        <h2>Start with the jobs to be done</h2>
+        <p>Operations managers need to know if agents are reducing handle time, compliance teams need assurance that sensitive phrases are redacted, and executives want to see adoption by region. We map these jobs and align data capture accordingly.</p>
+        <ol>
+          <li>Identify the persona and the decision they need to make.</li>
+          <li>Document what success looks like and the risk of not acting.</li>
+          <li>Design a data story that delivers that signal in under 60 seconds.</li>
+        </ol>
+
+        <h2>Instrument the full lifecycle</h2>
+        <p>Agent telemetry should cover prompt inputs, intermediate reasoning, outputs, human overrides, and customer feedback. Our Agent Programming Tool integration automatically tags every step so you can audit how conclusions were reached.</p>
+        <p>We recommend structuring logs in three layers:</p>
+        <ul>
+          <li><strong>Session context</strong>: user role, channel, customer type, data access scope.</li>
+          <li><strong>Action trace</strong>: prompts, tool invocations, decision checkpoints, confidence score.</li>
+          <li><strong>Outcome summary</strong>: resolution status, elapsed time, escalations, satisfaction rating.</li>
+        </ul>
+
+        <h2>Design dashboards for action</h2>
+        <p>Dashboards should lead to a decision, not simply display charts. We structure tiles using a “call, context, confirm” pattern: what needs attention, what happened, and what to do next. Linking dashboards to runbooks inside the agent UI closes the loop.</p>
+        <blockquote>“If the metric cannot trigger a playbook, it is just trivia.”</blockquote>
+
+        <h2>Establish rituals around the data</h2>
+        <p>Telemetry gains value when teams develop shared rituals. We host weekly stand-ups to review top exceptions, monthly compliance reviews, and quarterly executive briefings to align investment with outcomes. These cadences turn data into action.</p>
+
+        <p>Building telemetry that teams actually use requires empathy, discipline, and cross-functional collaboration. Pair the Agent Programming Tool’s rich logs with intentional design and you will create a monitoring practice that endures.</p>
+      </article>
+    </div>
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-brand">
+          <a class="logo" href="index.html">
+            <svg aria-hidden="true" viewBox="0 0 48 48">
+              <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+              <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+              <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+            </svg>
+            <span>Agent Web Applications</span>
+          </a>
+          <p>We design, govern, and scale AI agent web apps for regulated teams that need measurable outcomes.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="btn btn-ghost">Netshow.AI</a>
+        </div>
+        <div>
+          <h3 class="sr-only">Quick Links</h3>
+          <div class="footer-links">
+            <a href="index.html">Home</a>
+            <a href="about.html">About</a>
+            <a href="services.html">Services</a>
+            <a href="blog.html" aria-current="page">Blog</a>
+            <a href="faq.html">FAQ</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Legal Links</h3>
+          <div class="footer-links">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="disclosure.html">Disclosure</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Contact Information</h3>
+          <div class="footer-links">
+            <span>99 Market Street, Suite 540<br>San Francisco, CA 94105</span>
+            <a href="tel:+14155550123">+1 (415) 555-0123</a>
+            <a href="mailto:hello@agentwebapplications.com">hello@agentwebapplications.com</a>
+            <div class="social-links" aria-label="Social media">
+              <a href="https://www.facebook.com" aria-label="Facebook">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M14 8h2V5h-2c-2.2 0-4 1.8-4 4v2H8v3h2v7h3v-7h3l1-3h-4V9c0-.6.4-1 1-1z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.twitter.com" aria-label="X">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4 4l7.5 7.5L4 20h3.5l5.2-6 5.1 6H20l-7.4-8L20 4h-3.4l-4.7 5.5L7.2 4z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.instagram.com" aria-label="Instagram">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <rect x="3" y="3" width="18" height="18" rx="5" ry="5" fill="none" stroke="currentColor" stroke-width="2"></rect>
+                  <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="2"></circle>
+                  <circle cx="17" cy="7" r="1.5" fill="currentColor"></circle>
+                </svg>
+              </a>
+              <a href="https://www.linkedin.com" aria-label="LinkedIn">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4.98 3.5a2 2 0 1 1 0 4 2 2 0 0 1 0-4zM4 8.75h2.1V20H4zM9.25 8.75H11.3v1.54h.03c.29-.55 1-1.13 2.06-1.13 2.2 0 2.6 1.45 2.6 3.33V20h-2.1v-6c0-1.43-.03-3.26-1.99-3.26-1.99 0-2.3 1.55-2.3 3.15V20H9.25z" fill="currentColor"></path>
+                </svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© 2025 Agent Web Applications. All Rights Reserved.</span>
+        <span>Built for intelligent orchestration of web-based AI agents.</span>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/agentwebapplications.com/blog-article-3.html
+++ b/agentwebapplications.com/blog-article-3.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Rolling out agent web apps without breaking trust | Agent Web Applications</title>
+  <meta name="description" content="Agent Web Applications shares rollout strategies that help teams deploy AI agent web apps with transparency and stakeholder confidence.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+  <script defer src="js/script.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <div id="login" class="sr-only" aria-hidden="true">Client portal access for subscribers is handled through our secure workspace.</div>
+  <header class="site-header" role="banner">
+    <div class="container nav-wrapper">
+      <a class="logo" href="index.html" aria-label="Agent Web Applications home">
+        <svg aria-hidden="true" viewBox="0 0 48 48">
+          <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+          <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+          <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+        </svg>
+        <span>Agent Web Applications</span>
+      </a>
+      <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+      <nav class="primary-nav" id="primary-navigation" aria-label="Primary navigation">
+        <ul class="nav-list">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li class="nav-dropdown">
+            <button class="dropdown-toggle" type="button" data-dropdown-toggle aria-expanded="false" aria-haspopup="true">
+              Services
+              <svg aria-hidden="true" viewBox="0 0 16 16">
+                <path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+            <ul class="dropdown-menu" data-dropdown-menu>
+              <li><a href="services.html#tier-basic">Launch Pad (Basic)</a></li>
+              <li><a href="services.html#tier-pro">Workflow Studio (Pro)</a></li>
+              <li><a href="services.html#tier-enterprise">Co-Pilot Cloud (Enterprise)</a></li>
+            </ul>
+          </li>
+          <li><a href="blog.html" aria-current="page">Blog</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <div class="nav-actions">
+        <a class="btn btn-secondary" href="#login">Login</a>
+        <a class="btn btn-primary" href="demo.html">Request a Demo</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
+          <span aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img">
+              <path d="M12 4a1 1 0 0 1 1 1v2.06a1 1 0 0 1-2 0V5a1 1 0 0 1 1-1zm6.36 3.64a1 1 0 0 1 0 1.41l-1.46 1.46a1 1 0 0 1-1.41-1.41l1.46-1.46a1 1 0 0 1 1.41 0zM19 11h2a1 1 0 0 1 0 2h-2a1 1 0 0 1 0-2zm-7 7a1 1 0 0 1 1-1h2.06a1 1 0 0 1 0 2H13a1 1 0 0 1-1-1zm-5.95-1.05a1 1 0 0 1 1.41 0l1.46 1.46a1 1 0 0 1-1.41 1.41l-1.46-1.46a1 1 0 0 1 0-1.41zM5 11a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2h2zm1.05-5.95a1 1 0 0 1 1.41 0l1.46 1.46A1 1 0 0 1 7.51 7.92L6.05 6.46a1 1 0 0 1 0-1.41z" fill="currentColor"></path>
+              <circle cx="12" cy="12" r="3" fill="currentColor"></circle>
+            </svg>
+          </span>
+          <span data-theme-label>Switch to dark mode</span>
+        </button>
+      </div>
+    </div>
+  </header>
+  <main id="main" class="section">
+    <div class="container">
+      <article class="article">
+        <header>
+          <p class="blog-meta" style="gap:1.5rem;">
+            <span>November 18, 2024</span>
+            <span class="tag">
+              <svg viewBox="0 0 16 16" aria-hidden="true">
+                <path d="M7 1l6 6-6 6H1V7z" fill="currentColor"></path>
+              </svg>
+              Deployment
+            </span>
+          </p>
+          <h1>Rolling out agent web apps without breaking trust</h1>
+          <p>Agent rollouts can fail if stakeholders feel blindsided. At Agent Web Applications we choreograph launches so that every operator, compliance lead, and executive understands what is changing and why.</p>
+        </header>
+
+        <h2>Start with transparent pilots</h2>
+        <p>We begin in shadow mode, letting the agent observe real workflows and produce recommendations without taking action. Operators review these outputs during daily huddles. Only once accuracy and guardrail adherence are validated do we graduate to guided mode, where the agent drafts responses that humans send.</p>
+        <p>This phased approach builds muscle memory and earns confidence before any autonomy is introduced.</p>
+
+        <h2>Create a trust communications plan</h2>
+        <p>Every rollout includes communications tailored to each audience:</p>
+        <ul>
+          <li><strong>Operators</strong>: quick-start videos, cheat sheets, and real-time chat support.</li>
+          <li><strong>Compliance</strong>: documentation of guardrails, escalation ladders, and monitoring cadences.</li>
+          <li><strong>Executives</strong>: impact dashboards, ROI forecasts, and customer satisfaction trends.</li>
+        </ul>
+
+        <h2>Measure sentiment alongside metrics</h2>
+        <p>Hard metrics matter, but so does perception. We embed pulse surveys into the agent UI so operators can flag confusion, friction, or trust issues. Combining sentiment with telemetry highlights where additional training or policy updates are needed.</p>
+
+        <h2>Lock in a continuous improvement loop</h2>
+        <p>After go-live, we meet weekly to review performance, exceptions, and operator feedback. We plan incremental releases to extend agent scope, each with its own validation criteria. Maintaining this loop keeps stakeholders engaged long after the initial excitement fades.</p>
+
+        <p>Trust is earned every day. By making transparency and collaboration core to your rollout plan, agent web apps can become the most trusted tools in your organization.</p>
+      </article>
+    </div>
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-brand">
+          <a class="logo" href="index.html">
+            <svg aria-hidden="true" viewBox="0 0 48 48">
+              <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+              <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+              <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+            </svg>
+            <span>Agent Web Applications</span>
+          </a>
+          <p>We design, govern, and scale AI agent web apps for regulated teams that need measurable outcomes.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="btn btn-ghost">Netshow.AI</a>
+        </div>
+        <div>
+          <h3 class="sr-only">Quick Links</h3>
+          <div class="footer-links">
+            <a href="index.html">Home</a>
+            <a href="about.html">About</a>
+            <a href="services.html">Services</a>
+            <a href="blog.html" aria-current="page">Blog</a>
+            <a href="faq.html">FAQ</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Legal Links</h3>
+          <div class="footer-links">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="disclosure.html">Disclosure</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Contact Information</h3>
+          <div class="footer-links">
+            <span>99 Market Street, Suite 540<br>San Francisco, CA 94105</span>
+            <a href="tel:+14155550123">+1 (415) 555-0123</a>
+            <a href="mailto:hello@agentwebapplications.com">hello@agentwebapplications.com</a>
+            <div class="social-links" aria-label="Social media">
+              <a href="https://www.facebook.com" aria-label="Facebook">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M14 8h2V5h-2c-2.2 0-4 1.8-4 4v2H8v3h2v7h3v-7h3l1-3h-4V9c0-.6.4-1 1-1z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.twitter.com" aria-label="X">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4 4l7.5 7.5L4 20h3.5l5.2-6 5.1 6H20l-7.4-8L20 4h-3.4l-4.7 5.5L7.2 4z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.instagram.com" aria-label="Instagram">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <rect x="3" y="3" width="18" height="18" rx="5" ry="5" fill="none" stroke="currentColor" stroke-width="2"></rect>
+                  <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="2"></circle>
+                  <circle cx="17" cy="7" r="1.5" fill="currentColor"></circle>
+                </svg>
+              </a>
+              <a href="https://www.linkedin.com" aria-label="LinkedIn">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4.98 3.5a2 2 0 1 1 0 4 2 2 0 0 1 0-4zM4 8.75h2.1V20H4zM9.25 8.75H11.3v1.54h.03c.29-.55 1-1.13 2.06-1.13 2.2 0 2.6 1.45 2.6 3.33V20h-2.1v-6c0-1.43-.03-3.26-1.99-3.26-1.99 0-2.3 1.55-2.3 3.15V20H9.25z" fill="currentColor"></path>
+                </svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© 2025 Agent Web Applications. All Rights Reserved.</span>
+        <span>Built for intelligent orchestration of web-based AI agents.</span>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/agentwebapplications.com/blog.html
+++ b/agentwebapplications.com/blog.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Insights Blog | Agent Web Applications</title>
+  <meta name="description" content="Read articles about regulated AI agent design, observability, and governance from the Agent Web Applications team.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+  <script defer src="js/script.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <div id="login" class="sr-only" aria-hidden="true">Client portal access for subscribers is handled through our secure workspace.</div>
+  <header class="site-header" role="banner">
+    <div class="container nav-wrapper">
+      <a class="logo" href="index.html" aria-label="Agent Web Applications home">
+        <svg aria-hidden="true" viewBox="0 0 48 48">
+          <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+          <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+          <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+        </svg>
+        <span>Agent Web Applications</span>
+      </a>
+      <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+      <nav class="primary-nav" id="primary-navigation" aria-label="Primary navigation">
+        <ul class="nav-list">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li class="nav-dropdown">
+            <button class="dropdown-toggle" type="button" data-dropdown-toggle aria-expanded="false" aria-haspopup="true">
+              Services
+              <svg aria-hidden="true" viewBox="0 0 16 16">
+                <path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+            <ul class="dropdown-menu" data-dropdown-menu>
+              <li><a href="services.html#tier-basic">Launch Pad (Basic)</a></li>
+              <li><a href="services.html#tier-pro">Workflow Studio (Pro)</a></li>
+              <li><a href="services.html#tier-enterprise">Co-Pilot Cloud (Enterprise)</a></li>
+            </ul>
+          </li>
+          <li><a href="blog.html" aria-current="page">Blog</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <div class="nav-actions">
+        <a class="btn btn-secondary" href="#login">Login</a>
+        <a class="btn btn-primary" href="demo.html">Request a Demo</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
+          <span aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img">
+              <path d="M12 4a1 1 0 0 1 1 1v2.06a1 1 0 0 1-2 0V5a1 1 0 0 1 1-1zm6.36 3.64a1 1 0 0 1 0 1.41l-1.46 1.46a1 1 0 0 1-1.41-1.41l1.46-1.46a1 1 0 0 1 1.41 0zM19 11h2a1 1 0 0 1 0 2h-2a1 1 0 0 1 0-2zm-7 7a1 1 0 0 1 1-1h2.06a1 1 0 0 1 0 2H13a1 1 0 0 1-1-1zm-5.95-1.05a1 1 0 0 1 1.41 0l1.46 1.46a1 1 0 0 1-1.41 1.41l-1.46-1.46a1 1 0 0 1 0-1.41zM5 11a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2h2zm1.05-5.95a1 1 0 0 1 1.41 0l1.46 1.46A1 1 0 0 1 7.51 7.92L6.05 6.46a1 1 0 0 1 0-1.41z" fill="currentColor"></path>
+              <circle cx="12" cy="12" r="3" fill="currentColor"></circle>
+            </svg>
+          </span>
+          <span data-theme-label>Switch to dark mode</span>
+        </button>
+      </div>
+    </div>
+  </header>
+  <main id="main">
+    <section class="section">
+      <div class="container">
+        <div class="section-header">
+          <h1>Insights from the agent orchestration studio</h1>
+          <p>Practical analysis on building responsible, human-guided agent web applications for regulated industries.</p>
+        </div>
+        <div class="blog-grid">
+          <article class="blog-card">
+            <img src="images/blog-card-1.svg" alt="Abstract illustration for agent governance">
+            <div class="blog-card-body">
+              <div class="blog-meta">
+                <span>January 22, 2025</span>
+                <span class="tag">
+                  <svg viewBox="0 0 16 16" aria-hidden="true">
+                    <path d="M7 1l6 6-6 6H1V7z" fill="currentColor"></path>
+                  </svg>
+                  Governance
+                </span>
+              </div>
+              <h3><a href="blog-article-1.html">Five pillars of trustworthy agent governance</a></h3>
+              <p>What we learned implementing oversight for autonomous workflows inside hospitals, airlines, and energy providers.</p>
+            </div>
+          </article>
+          <article class="blog-card">
+            <img src="images/blog-card-2.svg" alt="Bar chart illustration for analytics">
+            <div class="blog-card-body">
+              <div class="blog-meta">
+                <span>December 12, 2024</span>
+                <span class="tag">
+                  <svg viewBox="0 0 16 16" aria-hidden="true">
+                    <path d="M7 1l6 6-6 6H1V7z" fill="currentColor"></path>
+                  </svg>
+                  Observability
+                </span>
+              </div>
+              <h3><a href="blog-article-2.html">Designing agent telemetry that teams actually use</a></h3>
+              <p>Discover the dashboards, alerts, and rituals that keep agent performance measurable without overwhelming analysts.</p>
+            </div>
+          </article>
+          <article class="blog-card">
+            <img src="images/blog-card-3.svg" alt="Wave illustration for rollout strategy">
+            <div class="blog-card-body">
+              <div class="blog-meta">
+                <span>November 18, 2024</span>
+                <span class="tag">
+                  <svg viewBox="0 0 16 16" aria-hidden="true">
+                    <path d="M7 1l6 6-6 6H1V7z" fill="currentColor"></path>
+                  </svg>
+                  Deployment
+                </span>
+              </div>
+              <h3><a href="blog-article-3.html">Rolling out agent web apps without breaking trust</a></h3>
+              <p>Learn how to pilot, shadow, and scale agent-driven interfaces while keeping stakeholders confident at every stage.</p>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container final-cta">
+        <h2>Want updates in your inbox?</h2>
+        <p>Sign up to receive monthly briefings on agent governance, UI design patterns, and observability tactics from our studio.</p>
+        <form class="hero-form" data-validate="true" data-success-message="Thanks! Check your inbox for the latest insights." novalidate style="margin:0 auto; max-width:540px;">
+          <label class="sr-only" for="blog-email">Email address</label>
+          <input id="blog-email" type="email" name="email" placeholder="you@company.com" required>
+          <button class="btn btn-primary" type="submit">Subscribe</button>
+          <p class="form-message" aria-live="polite"></p>
+        </form>
+      </div>
+    </section>
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-brand">
+          <a class="logo" href="index.html">
+            <svg aria-hidden="true" viewBox="0 0 48 48">
+              <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+              <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+              <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+            </svg>
+            <span>Agent Web Applications</span>
+          </a>
+          <p>We design, govern, and scale AI agent web apps for regulated teams that need measurable outcomes.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="btn btn-ghost">Netshow.AI</a>
+        </div>
+        <div>
+          <h3 class="sr-only">Quick Links</h3>
+          <div class="footer-links">
+            <a href="index.html">Home</a>
+            <a href="about.html">About</a>
+            <a href="services.html">Services</a>
+            <a href="blog.html" aria-current="page">Blog</a>
+            <a href="faq.html">FAQ</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Legal Links</h3>
+          <div class="footer-links">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="disclosure.html">Disclosure</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Contact Information</h3>
+          <div class="footer-links">
+            <span>99 Market Street, Suite 540<br>San Francisco, CA 94105</span>
+            <a href="tel:+14155550123">+1 (415) 555-0123</a>
+            <a href="mailto:hello@agentwebapplications.com">hello@agentwebapplications.com</a>
+            <div class="social-links" aria-label="Social media">
+              <a href="https://www.facebook.com" aria-label="Facebook">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M14 8h2V5h-2c-2.2 0-4 1.8-4 4v2H8v3h2v7h3v-7h3l1-3h-4V9c0-.6.4-1 1-1z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.twitter.com" aria-label="X">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4 4l7.5 7.5L4 20h3.5l5.2-6 5.1 6H20l-7.4-8L20 4h-3.4l-4.7 5.5L7.2 4z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.instagram.com" aria-label="Instagram">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <rect x="3" y="3" width="18" height="18" rx="5" ry="5" fill="none" stroke="currentColor" stroke-width="2"></rect>
+                  <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="2"></circle>
+                  <circle cx="17" cy="7" r="1.5" fill="currentColor"></circle>
+                </svg>
+              </a>
+              <a href="https://www.linkedin.com" aria-label="LinkedIn">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4.98 3.5a2 2 0 1 1 0 4 2 2 0 0 1 0-4zM4 8.75h2.1V20H4zM9.25 8.75H11.3v1.54h.03c.29-.55 1-1.13 2.06-1.13 2.2 0 2.6 1.45 2.6 3.33V20h-2.1v-6c0-1.43-.03-3.26-1.99-3.26-1.99 0-2.3 1.55-2.3 3.15V20H9.25z" fill="currentColor"></path>
+                </svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© 2025 Agent Web Applications. All Rights Reserved.</span>
+        <span>Built for intelligent orchestration of web-based AI agents.</span>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/agentwebapplications.com/contact.html
+++ b/agentwebapplications.com/contact.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Contact | Agent Web Applications</title>
+  <meta name="description" content="Contact Agent Web Applications to discuss AI agent web app projects, support requests, or partnerships.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+  <script defer src="js/script.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <div id="login" class="sr-only" aria-hidden="true">Client portal access for subscribers is handled through our secure workspace.</div>
+  <header class="site-header" role="banner">
+    <div class="container nav-wrapper">
+      <a class="logo" href="index.html" aria-label="Agent Web Applications home">
+        <svg aria-hidden="true" viewBox="0 0 48 48">
+          <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+          <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+          <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+        </svg>
+        <span>Agent Web Applications</span>
+      </a>
+      <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+      <nav class="primary-nav" id="primary-navigation" aria-label="Primary navigation">
+        <ul class="nav-list">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li class="nav-dropdown">
+            <button class="dropdown-toggle" type="button" data-dropdown-toggle aria-expanded="false" aria-haspopup="true">
+              Services
+              <svg aria-hidden="true" viewBox="0 0 16 16">
+                <path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+            <ul class="dropdown-menu" data-dropdown-menu>
+              <li><a href="services.html#tier-basic">Launch Pad (Basic)</a></li>
+              <li><a href="services.html#tier-pro">Workflow Studio (Pro)</a></li>
+              <li><a href="services.html#tier-enterprise">Co-Pilot Cloud (Enterprise)</a></li>
+            </ul>
+          </li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="contact.html" aria-current="page">Contact</a></li>
+        </ul>
+      </nav>
+      <div class="nav-actions">
+        <a class="btn btn-secondary" href="#login">Login</a>
+        <a class="btn btn-primary" href="demo.html">Request a Demo</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
+          <span aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img">
+              <path d="M12 4a1 1 0 0 1 1 1v2.06a1 1 0 0 1-2 0V5a1 1 0 0 1 1-1zm6.36 3.64a1 1 0 0 1 0 1.41l-1.46 1.46a1 1 0 0 1-1.41-1.41l1.46-1.46a1 1 0 0 1 1.41 0zM19 11h2a1 1 0 0 1 0 2h-2a1 1 0 0 1 0-2zm-7 7a1 1 0 0 1 1-1h2.06a1 1 0 0 1 0 2H13a1 1 0 0 1-1-1zm-5.95-1.05a1 1 0 0 1 1.41 0l1.46 1.46a1 1 0 0 1-1.41 1.41l-1.46-1.46a1 1 0 0 1 0-1.41zM5 11a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2h2zm1.05-5.95a1 1 0 0 1 1.41 0l1.46 1.46A1 1 0 0 1 7.51 7.92L6.05 6.46a1 1 0 0 1 0-1.41z" fill="currentColor"></path>
+              <circle cx="12" cy="12" r="3" fill="currentColor"></circle>
+            </svg>
+          </span>
+          <span data-theme-label>Switch to dark mode</span>
+        </button>
+      </div>
+    </div>
+  </header>
+  <main id="main">
+    <section class="section">
+      <div class="container" style="display:grid; gap:2.5rem; grid-template-columns:repeat(auto-fit, minmax(280px, 1fr)); align-items:start;">
+        <div>
+          <div class="section-header" style="text-align:left; margin-bottom:1.5rem;">
+            <h1>Let's orchestrate your next agent experience</h1>
+            <p>Share your goals and we'll connect you with the right strategist, engineer, or compliance specialist.</p>
+          </div>
+          <form class="contact-form lead-form" data-validate="true" data-success-message="Thank you! We'll reply within one business day." novalidate>
+            <div>
+              <label for="contact-name">Name</label>
+              <input id="contact-name" type="text" name="name" placeholder="Alex Morgan" required>
+            </div>
+            <div>
+              <label for="contact-email">Email</label>
+              <input id="contact-email" type="email" name="email" placeholder="you@company.com" required>
+            </div>
+            <div>
+              <label for="contact-message">How can we help?</label>
+              <textarea id="contact-message" name="message" placeholder="Tell us about your workflows, timelines, or questions" required></textarea>
+            </div>
+            <p class="form-message" aria-live="polite"></p>
+            <button class="btn btn-primary" type="submit">Send message</button>
+          </form>
+        </div>
+        <div>
+          <h2>Contact details</h2>
+          <p>Our distributed team supports clients across North America, Europe, and Asia-Pacific. Reach out via your preferred channel.</p>
+          <div class="contact-info">
+            <span>
+              <svg viewBox="0 0 24 24" aria-hidden="true" style="width:20px; height:20px;">
+                <path d="M12 2C8.1 2 5 5.1 5 9c0 5.2 7 13 7 13s7-7.8 7-13c0-3.9-3.1-7-7-7zm0 9.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5z" fill="var(--color-primary)"></path>
+              </svg>
+              99 Market Street, Suite 540, San Francisco, CA 94105
+            </span>
+            <span>
+              <svg viewBox="0 0 24 24" aria-hidden="true" style="width:20px; height:20px;">
+                <path d="M6.6 10.8c1.2 2.4 3.2 4.5 5.6 5.6l1.9-1.9a1 1 0 0 1 1-.25 11.3 11.3 0 0 0 3.5.56 1 1 0 0 1 1 1v3.4a1 1 0 0 1-1 1A16.6 16.6 0 0 1 3 5a1 1 0 0 1 1-1h3.4a1 1 0 0 1 1 1 11.3 11.3 0 0 0 .56 3.5 1 1 0 0 1-.25 1z" fill="var(--color-primary)"></path>
+              </svg>
+              <a href="tel:+14155550123">+1 (415) 555-0123</a>
+            </span>
+            <span>
+              <svg viewBox="0 0 24 24" aria-hidden="true" style="width:20px; height:20px;">
+                <path d="M4 4h16a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1zm8 7l8-5H4l8 5zm0 2l-8-5v9h16v-9l-8 5z" fill="var(--color-primary)"></path>
+              </svg>
+              <a href="mailto:hello@agentwebapplications.com">hello@agentwebapplications.com</a>
+            </span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" style="padding-top:0;">
+      <div class="container">
+        <div class="map-wrapper">
+          <iframe title="Agent Web Applications San Francisco office" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3153.1137004187873!2d-122.40136332447981!3d37.79359331222517!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x80858064d1bbf0b5%3A0xf0b8b61c3428eb31!2s99%20Market%20St%2C%20San%20Francisco%2C%20CA%2094105!5e0!3m2!1sen!2sus!4v1700000000000!5m2!1sen!2sus" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+        </div>
+      </div>
+    </section>
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-brand">
+          <a class="logo" href="index.html">
+            <svg aria-hidden="true" viewBox="0 0 48 48">
+              <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+              <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+              <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+            </svg>
+            <span>Agent Web Applications</span>
+          </a>
+          <p>We design, govern, and scale AI agent web apps for regulated teams that need measurable outcomes.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="btn btn-ghost">Netshow.AI</a>
+        </div>
+        <div>
+          <h3 class="sr-only">Quick Links</h3>
+          <div class="footer-links">
+            <a href="index.html">Home</a>
+            <a href="about.html">About</a>
+            <a href="services.html">Services</a>
+            <a href="blog.html">Blog</a>
+            <a href="faq.html">FAQ</a>
+            <a href="contact.html" aria-current="page">Contact</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Legal Links</h3>
+          <div class="footer-links">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="disclosure.html">Disclosure</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Contact Information</h3>
+          <div class="footer-links">
+            <span>99 Market Street, Suite 540<br>San Francisco, CA 94105</span>
+            <a href="tel:+14155550123">+1 (415) 555-0123</a>
+            <a href="mailto:hello@agentwebapplications.com">hello@agentwebapplications.com</a>
+            <div class="social-links" aria-label="Social media">
+              <a href="https://www.facebook.com" aria-label="Facebook">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M14 8h2V5h-2c-2.2 0-4 1.8-4 4v2H8v3h2v7h3v-7h3l1-3h-4V9c0-.6.4-1 1-1z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.twitter.com" aria-label="X">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4 4l7.5 7.5L4 20h3.5l5.2-6 5.1 6H20l-7.4-8L20 4h-3.4l-4.7 5.5L7.2 4z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.instagram.com" aria-label="Instagram">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <rect x="3" y="3" width="18" height="18" rx="5" ry="5" fill="none" stroke="currentColor" stroke-width="2"></rect>
+                  <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="2"></circle>
+                  <circle cx="17" cy="7" r="1.5" fill="currentColor"></circle>
+                </svg>
+              </a>
+              <a href="https://www.linkedin.com" aria-label="LinkedIn">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4.98 3.5a2 2 0 1 1 0 4 2 2 0 0 1 0-4zM4 8.75h2.1V20H4zM9.25 8.75H11.3v1.54h.03c.29-.55 1-1.13 2.06-1.13 2.2 0 2.6 1.45 2.6 3.33V20h-2.1v-6c0-1.43-.03-3.26-1.99-3.26-1.99 0-2.3 1.55-2.3 3.15V20H9.25z" fill="currentColor"></path>
+                </svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© 2025 Agent Web Applications. All Rights Reserved.</span>
+        <span>Built for intelligent orchestration of web-based AI agents.</span>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/agentwebapplications.com/css/style.css
+++ b/agentwebapplications.com/css/style.css
@@ -1,0 +1,1111 @@
+/* Agent Web Applications Global Styles */
+/* Defines light/dark theme tokens and shared layout utilities. */
+:root {
+  color-scheme: light;
+  --color-bg: #f4f5ff;
+  --color-surface: #ffffff;
+  --color-text: #1f2241;
+  --color-muted: #5f6795;
+  --color-border: #d5daf8;
+  --color-primary: #3a3ad1;
+  --color-primary-soft: rgba(58, 58, 209, 0.1);
+  --color-accent: #f87b56;
+  --color-accent-soft: rgba(248, 123, 86, 0.14);
+  --color-highlight: #1ab7c4;
+  --shadow-sm: 0 10px 30px rgba(31, 34, 65, 0.08);
+  --shadow-lg: 0 32px 64px rgba(31, 34, 65, 0.12);
+  --font-heading: 'Poppins', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-body: 'Source Sans 3', 'Helvetica Neue', Arial, sans-serif;
+  --container-width: 1200px;
+  --transition-base: 0.3s ease;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --color-bg: #0f132b;
+  --color-surface: #161b38;
+  --color-text: #e6e8fb;
+  --color-muted: #a6acd8;
+  --color-border: #2e3464;
+  --color-primary: #8187ff;
+  --color-primary-soft: rgba(129, 135, 255, 0.15);
+  --color-accent: #ff9d77;
+  --color-accent-soft: rgba(255, 157, 119, 0.16);
+  --color-highlight: #4ad7e4;
+  --shadow-sm: 0 10px 30px rgba(6, 7, 18, 0.55);
+  --shadow-lg: 0 32px 64px rgba(2, 3, 12, 0.55);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  color: var(--color-text);
+  background-color: var(--color-bg);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+a {
+  color: var(--color-primary);
+  text-decoration: none;
+  transition: color var(--transition-base);
+}
+
+a:hover,
+a:focus {
+  color: var(--color-accent);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+svg {
+  max-width: 100%;
+  height: auto;
+}
+
+main {
+  display: block;
+}
+
+.container {
+  width: min(92%, var(--container-width));
+  margin: 0 auto;
+}
+
+.section {
+  padding: 4.5rem 0;
+}
+
+.section-header {
+  margin-bottom: 2.5rem;
+  text-align: center;
+}
+
+.section-header h2 {
+  font-family: var(--font-heading);
+  font-weight: 600;
+  font-size: clamp(2rem, 3vw, 2.5rem);
+  margin: 0 0 0.75rem;
+}
+
+.section-header p {
+  color: var(--color-muted);
+  margin: 0 auto;
+  max-width: 640px;
+}
+
+.btn {
+  font-family: var(--font-heading);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.6rem;
+  border-radius: 999px;
+  border: 2px solid transparent;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color var(--transition-base), color var(--transition-base), transform var(--transition-base), border-color var(--transition-base);
+}
+
+.btn-primary {
+  background: var(--color-primary);
+  color: #fff;
+  box-shadow: var(--shadow-sm);
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+  background: var(--color-accent);
+  transform: translateY(-1px);
+}
+
+.btn-secondary {
+  background: transparent;
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+
+.btn-secondary:hover,
+.btn-secondary:focus {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.btn-ghost {
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+}
+
+.btn-ghost:hover,
+.btn-ghost:focus {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: 1rem;
+  background: var(--color-primary);
+  color: #fff;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  z-index: 9999;
+}
+
+.skip-link:focus {
+  left: 1rem;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 9000;
+  backdrop-filter: blur(12px);
+  background: var(--color-bg);
+  background: color-mix(in srgb, var(--color-bg) 80%, transparent);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.nav-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0;
+  gap: 1rem;
+}
+
+.logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-family: var(--font-heading);
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.logo svg {
+  width: 40px;
+  height: 40px;
+}
+
+.primary-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.nav-list {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-list a,
+.nav-list button {
+  font-family: var(--font-heading);
+  font-weight: 500;
+  color: var(--color-text);
+  background: none;
+  border: none;
+  padding: 0.35rem 0.5rem;
+  cursor: pointer;
+}
+
+.nav-list a:hover,
+.nav-list a:focus,
+.nav-list button:hover,
+.nav-list button:focus {
+  color: var(--color-primary);
+}
+
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.theme-toggle {
+  background: var(--color-primary-soft);
+  border-radius: 999px;
+  border: none;
+  padding: 0.5rem 0.85rem;
+  color: var(--color-primary);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--font-heading);
+  font-weight: 600;
+}
+
+.theme-toggle svg {
+  width: 20px;
+  height: 20px;
+}
+
+.menu-toggle {
+  display: none;
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  padding: 0.6rem 0.8rem;
+  border-radius: 0.75rem;
+}
+
+.nav-dropdown {
+  position: relative;
+}
+
+.dropdown-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.dropdown-menu {
+  position: absolute;
+  top: 120%;
+  left: 0;
+  min-width: 200px;
+  background: var(--color-surface);
+  border-radius: 1rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  list-style: none;
+  padding: 0.75rem 0;
+  margin: 0;
+  display: none;
+}
+
+.dropdown-menu.show {
+  display: block;
+}
+
+.dropdown-menu a {
+  display: block;
+  padding: 0.6rem 1.2rem;
+  color: var(--color-text);
+}
+
+.dropdown-menu a:hover,
+.dropdown-menu a:focus {
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+}
+
+.hero {
+  padding: 6rem 0 5rem;
+}
+
+.hero-grid {
+  display: grid;
+  gap: 3rem;
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.hero-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  font-weight: 600;
+  font-family: var(--font-heading);
+  margin-bottom: 1rem;
+}
+
+.hero h1 {
+  font-family: var(--font-heading);
+  font-size: clamp(2.6rem, 5vw, 3.4rem);
+  line-height: 1.1;
+  margin: 0 0 1.5rem;
+}
+
+.hero p {
+  color: var(--color-muted);
+  margin-bottom: 2rem;
+  max-width: 580px;
+}
+
+.hero-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  background: var(--color-surface);
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  padding: 0.5rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.hero-form input[type="email"] {
+  flex: 1;
+  min-width: 200px;
+  border: none;
+  padding: 0.8rem 1rem;
+  border-radius: 999px;
+  font-size: 1rem;
+  font-family: var(--font-body);
+  background: transparent;
+  color: var(--color-text);
+}
+
+.hero-form input[type="email"]:focus {
+  outline: none;
+}
+
+.hero-form button {
+  white-space: nowrap;
+}
+
+.hero-link {
+  display: inline-flex;
+  margin-top: 1rem;
+  font-weight: 600;
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+  padding: 0.5rem 1rem;
+  border-radius: 0.75rem;
+}
+
+.hero-media {
+  position: relative;
+  padding: 2rem;
+}
+
+.hero-media::after {
+  content: '';
+  position: absolute;
+  inset: 10% 8% 0 18%;
+  background: var(--color-primary-soft);
+  border-radius: 2rem;
+  z-index: -1;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.5rem;
+  margin-top: 3rem;
+}
+
+.stat-card {
+  background: var(--color-surface);
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  text-align: left;
+}
+
+.stat-card h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.8rem;
+  font-family: var(--font-heading);
+}
+
+.stat-card p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.how-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.8rem;
+}
+
+.how-card {
+  background: var(--color-surface);
+  border-radius: 1.5rem;
+  padding: 1.75rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+}
+
+.how-card svg {
+  width: 48px;
+  height: 48px;
+  margin-bottom: 1rem;
+}
+
+.how-card h3 {
+  margin: 0 0 0.75rem;
+  font-family: var(--font-heading);
+}
+
+.how-card p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.feature-card {
+  background: var(--color-surface);
+  border-radius: 1.5rem;
+  padding: 1.75rem;
+  border: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.feature-card svg {
+  width: 44px;
+  height: 44px;
+}
+
+.feature-card h3 {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-size: 1.1rem;
+}
+
+.feature-card p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.testimonials {
+  background: var(--color-primary-soft);
+}
+
+.testimonials-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.testimonial-card {
+  background: var(--color-surface);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.testimonial-head {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.testimonial-head img {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+}
+
+.testimonial-card p {
+  margin: 0;
+}
+
+.testimonial-card cite {
+  font-style: normal;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.featured-logos {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.5rem;
+  align-items: center;
+  justify-items: center;
+}
+
+.final-cta {
+  text-align: center;
+  padding: 4rem 0;
+  background: var(--color-primary-soft);
+  border-radius: 2rem;
+  margin-top: 4rem;
+  box-shadow: var(--shadow-lg);
+}
+
+.final-cta h2 {
+  margin-bottom: 1rem;
+  font-family: var(--font-heading);
+  font-size: clamp(2.1rem, 4vw, 2.8rem);
+}
+
+.final-cta p {
+  margin: 0 auto 2rem;
+  color: var(--color-muted);
+  max-width: 540px;
+}
+
+.cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.profile-card {
+  background: var(--color-surface);
+  border-radius: 1.5rem;
+  padding: 1.8rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  text-align: center;
+}
+
+.profile-card img {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  margin: 0 auto 1rem;
+}
+
+.profile-card h3 {
+  margin: 0.5rem 0 0.25rem;
+  font-family: var(--font-heading);
+}
+
+.profile-card p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.values-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.value-card {
+  padding: 1.5rem;
+  border-radius: 1.5rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+}
+
+.plan-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 3rem;
+}
+
+.plan-card {
+  background: var(--color-surface);
+  border-radius: 1.5rem;
+  border: 1px solid var(--color-border);
+  padding: 2rem;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.plan-card h3 {
+  font-family: var(--font-heading);
+  margin: 0;
+}
+
+.plan-card .price {
+  font-size: 2rem;
+  font-family: var(--font-heading);
+  color: var(--color-primary);
+}
+
+.plan-card ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+  color: var(--color-muted);
+}
+
+.comparison-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--color-surface);
+  border-radius: 1.5rem;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+}
+
+.comparison-table th,
+.comparison-table td {
+  padding: 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.comparison-table th {
+  background: var(--color-primary-soft);
+  font-family: var(--font-heading);
+}
+
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+}
+
+.product-card {
+  background: var(--color-surface);
+  border-radius: 1.5rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.product-card img {
+  width: 100%;
+  object-fit: cover;
+}
+
+.product-card .product-body {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.product-card h3 {
+  margin: 0;
+  font-family: var(--font-heading);
+}
+
+.demo-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+  align-items: center;
+}
+
+.demo-video {
+  position: relative;
+}
+
+.lead-form {
+  background: var(--color-surface);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  display: grid;
+  gap: 1rem;
+}
+
+.lead-form label {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.lead-form input,
+.lead-form textarea,
+.contact-form input,
+.contact-form textarea,
+.hero-form input {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 0.9rem;
+  padding: 0.8rem 1rem;
+  font-size: 1rem;
+  font-family: var(--font-body);
+  color: var(--color-text);
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
+}
+
+.lead-form input:focus,
+.lead-form textarea:focus,
+.contact-form input:focus,
+.contact-form textarea:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 4px var(--color-primary-soft);
+  outline: none;
+}
+
+.lead-form textarea,
+.contact-form textarea {
+  resize: vertical;
+  min-height: 140px;
+}
+
+.form-message {
+  margin: 0;
+  font-weight: 600;
+  color: var(--color-accent);
+  min-height: 1.2rem;
+}
+
+.blog-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+}
+
+.blog-card {
+  background: var(--color-surface);
+  border-radius: 1.5rem;
+  border: 1px solid var(--color-border);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+}
+
+.blog-card img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+}
+
+.blog-card-body {
+  padding: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.blog-card-body h3 {
+  margin: 0;
+  font-family: var(--font-heading);
+}
+
+.blog-meta {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.article {
+  background: var(--color-surface);
+  border-radius: 2rem;
+  padding: 3rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+}
+
+.article h1 {
+  font-family: var(--font-heading);
+  margin-top: 0;
+}
+
+.article h2 {
+  font-family: var(--font-heading);
+  margin-top: 2.5rem;
+}
+
+.article p {
+  color: var(--color-text);
+}
+
+.article blockquote {
+  margin: 2rem 0;
+  padding: 1.5rem;
+  border-left: 4px solid var(--color-primary);
+  background: var(--color-primary-soft);
+  border-radius: 1rem;
+  color: var(--color-text);
+}
+
+.contact-info {
+  display: grid;
+  gap: 1rem;
+  margin: 2rem 0;
+}
+
+.contact-info span {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-muted);
+}
+
+.map-wrapper iframe {
+  width: 100%;
+  min-height: 320px;
+  border: 0;
+  border-radius: 1.5rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.faq-list {
+  display: grid;
+  gap: 1rem;
+  max-width: 840px;
+  margin: 0 auto;
+}
+
+.faq-list details {
+  background: var(--color-surface);
+  border-radius: 1.5rem;
+  padding: 1.2rem 1.5rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+}
+
+.faq-list summary {
+  cursor: pointer;
+  font-family: var(--font-heading);
+  font-weight: 600;
+  list-style: none;
+}
+
+.faq-list summary::-webkit-details-marker {
+  display: none;
+}
+
+.faq-list details[open] summary {
+  color: var(--color-primary);
+}
+
+.review-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+}
+
+.review-card {
+  background: var(--color-surface);
+  border-radius: 1.5rem;
+  border: 1px solid var(--color-border);
+  padding: 2rem;
+  box-shadow: var(--shadow-sm);
+  display: grid;
+  gap: 1rem;
+}
+
+.case-study {
+  background: var(--color-primary-soft);
+  border-radius: 2rem;
+  padding: 3rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  align-items: center;
+  box-shadow: var(--shadow-lg);
+}
+
+.case-study img {
+  max-width: 220px;
+}
+
+.legal {
+  background: var(--color-surface);
+  border-radius: 2rem;
+  padding: 3rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.legal h1 {
+  font-family: var(--font-heading);
+  margin: 0;
+}
+
+.legal h2 {
+  font-family: var(--font-heading);
+  margin-top: 2rem;
+}
+
+.site-footer {
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+  margin-top: 4rem;
+}
+
+.footer-inner {
+  width: min(92%, var(--container-width));
+  margin: 0 auto;
+  padding: 3rem 0;
+  display: grid;
+  gap: 2.5rem;
+}
+
+.footer-top {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2rem;
+}
+
+.footer-brand {
+  display: grid;
+  gap: 1rem;
+}
+
+.footer-brand p {
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.footer-links {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.footer-links a {
+  color: var(--color-muted);
+}
+
+.footer-links a:hover,
+.footer-links a:focus {
+  color: var(--color-primary);
+}
+
+.social-links {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.social-links a {
+  display: inline-flex;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+}
+
+.social-links a:hover,
+.social-links a:focus {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.footer-bottom {
+  border-top: 1px solid var(--color-border);
+  padding-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.table-scroll {
+  overflow-x: auto;
+  padding-bottom: 1rem;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  font-size: 0.85rem;
+}
+
+.tag svg {
+  width: 16px;
+  height: 16px;
+}
+
+@media (max-width: 960px) {
+  .primary-nav {
+    position: fixed;
+    inset: 0 0 0 40%;
+    background: var(--color-surface);
+    flex-direction: column;
+    justify-content: center;
+    gap: 2rem;
+    padding: 4rem 2rem;
+    transform: translateX(100%);
+    transition: transform var(--transition-base);
+    box-shadow: var(--shadow-lg);
+  }
+
+  .primary-nav.open {
+    transform: translateX(0);
+  }
+
+  .nav-list {
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .menu-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 640px) {
+  .nav-wrapper {
+    flex-wrap: wrap;
+  }
+
+  .hero-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .hero-form input[type="email"] {
+    min-width: auto;
+    width: 100%;
+  }
+
+  .final-cta {
+    border-radius: 1.5rem;
+  }
+
+  .article {
+    padding: 2rem;
+  }
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.input-error {
+  border-color: var(--color-accent) !important;
+  box-shadow: 0 0 0 4px var(--color-accent-soft) !important;
+}

--- a/agentwebapplications.com/demo.html
+++ b/agentwebapplications.com/demo.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Interactive Demo | Agent Web Applications</title>
+  <meta name="description" content="Watch the Agent Web Applications demo built with the Agent Programming Tool stack and request a guided tour tailored to your workflows.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+  <script defer src="js/script.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <div id="login" class="sr-only" aria-hidden="true">Client portal access for subscribers is handled through our secure workspace.</div>
+  <header class="site-header" role="banner">
+    <div class="container nav-wrapper">
+      <a class="logo" href="index.html" aria-label="Agent Web Applications home">
+        <svg aria-hidden="true" viewBox="0 0 48 48">
+          <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+          <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+          <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+        </svg>
+        <span>Agent Web Applications</span>
+      </a>
+      <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+      <nav class="primary-nav" id="primary-navigation" aria-label="Primary navigation">
+        <ul class="nav-list">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li class="nav-dropdown">
+            <button class="dropdown-toggle" type="button" data-dropdown-toggle aria-expanded="false" aria-haspopup="true">
+              Services
+              <svg aria-hidden="true" viewBox="0 0 16 16">
+                <path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+            <ul class="dropdown-menu" data-dropdown-menu>
+              <li><a href="services.html#tier-basic">Launch Pad (Basic)</a></li>
+              <li><a href="services.html#tier-pro">Workflow Studio (Pro)</a></li>
+              <li><a href="services.html#tier-enterprise">Co-Pilot Cloud (Enterprise)</a></li>
+            </ul>
+          </li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <div class="nav-actions">
+        <a class="btn btn-secondary" href="#login">Login</a>
+        <a class="btn btn-primary" href="demo.html" aria-current="page">Request a Demo</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
+          <span aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img">
+              <path d="M12 4a1 1 0 0 1 1 1v2.06a1 1 0 0 1-2 0V5a1 1 0 0 1 1-1zm6.36 3.64a1 1 0 0 1 0 1.41l-1.46 1.46a1 1 0 0 1-1.41-1.41l1.46-1.46a1 1 0 0 1 1.41 0zM19 11h2a1 1 0 0 1 0 2h-2a1 1 0 0 1 0-2zm-7 7a1 1 0 0 1 1-1h2.06a1 1 0 0 1 0 2H13a1 1 0 0 1-1-1zm-5.95-1.05a1 1 0 0 1 1.41 0l1.46 1.46a1 1 0 0 1-1.41 1.41l-1.46-1.46a1 1 0 0 1 0-1.41zM5 11a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2h2zm1.05-5.95a1 1 0 0 1 1.41 0l1.46 1.46A1 1 0 0 1 7.51 7.92L6.05 6.46a1 1 0 0 1 0-1.41z" fill="currentColor"></path>
+              <circle cx="12" cy="12" r="3" fill="currentColor"></circle>
+            </svg>
+          </span>
+          <span data-theme-label>Switch to dark mode</span>
+        </button>
+      </div>
+    </div>
+  </header>
+  <main id="main">
+    <section class="section">
+      <div class="container demo-hero">
+        <div>
+          <div class="section-header" style="text-align:left; margin-bottom:1.5rem;">
+            <h1>Preview the Agent Programming Tool experience</h1>
+            <p>The interactive demo showcases how Agent Web Applications composes the Agent Programming Tool stack into a branded, policy-aware web experience. Watch the high-level walkthrough or request a guided session.</p>
+          </div>
+          <div class="values-list" style="margin-top:0; grid-template-columns:1fr; gap:1rem;">
+            <div class="value-card" style="display:flex; gap:1rem; align-items:flex-start;">
+              <svg aria-hidden="true" viewBox="0 0 32 32" style="width:36px; height:36px;">
+                <circle cx="16" cy="16" r="16" fill="var(--color-primary-soft)"></circle>
+                <path d="M10 16l4 4 8-8" fill="none" stroke="var(--color-primary)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+              <div>
+                <h3 style="margin-top:0;">See orchestration in action</h3>
+                <p>The demo maps two coordinated agents resolving a clinical intake case while compliance checks run silently in the background.</p>
+              </div>
+            </div>
+            <div class="value-card" style="display:flex; gap:1rem; align-items:flex-start;">
+              <svg aria-hidden="true" viewBox="0 0 32 32" style="width:36px; height:36px;">
+                <circle cx="16" cy="16" r="16" fill="var(--color-accent-soft)"></circle>
+                <path d="M11 21h10M16 11v10" stroke="var(--color-accent)" stroke-width="3" stroke-linecap="round"></path>
+              </svg>
+              <div>
+                <h3 style="margin-top:0;">Explore guided guardrails</h3>
+                <p>Follow how human approvals, escalation prompts, and data retention policies surface exactly when operators need them.</p>
+              </div>
+            </div>
+            <div class="value-card" style="display:flex; gap:1rem; align-items:flex-start;">
+              <svg aria-hidden="true" viewBox="0 0 32 32" style="width:36px; height:36px;">
+                <circle cx="16" cy="16" r="16" fill="var(--color-primary-soft)"></circle>
+                <path d="M10 20h12l-6 6z" fill="var(--color-primary)"></path>
+                <path d="M10 12h12" stroke="var(--color-accent)" stroke-width="3" stroke-linecap="round"></path>
+              </svg>
+              <div>
+                <h3 style="margin-top:0;">Inspect live telemetry</h3>
+                <p>Review the observability overlay capturing prompts, outputs, and reviewer comments—powered by Agent Programming Tool metrics.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="demo-video">
+          <img src="images/demo-video.svg" alt="Placeholder preview of the Agent Web Applications demo video interface.">
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="request-demo">
+      <div class="container" style="display:grid; gap:2rem; grid-template-columns:repeat(auto-fit, minmax(280px, 1fr)); align-items:start;">
+        <div>
+          <h2>Request a personalized demo</h2>
+          <p>Tell us about your workflows and compliance landscape. We will tailor the Agent Programming Tool walkthrough to your data sources, staffing model, and regulatory obligations.</p>
+          <ul style="list-style:none; padding:0; margin:2rem 0; display:grid; gap:1rem;">
+            <li class="tag">
+              <svg viewBox="0 0 16 16" aria-hidden="true">
+                <path d="M6.5 10.5l-2-2 1.4-1.4 0.6 0.59 3.6-3.59L11.5 5.5z" fill="currentColor"></path>
+              </svg>
+              45-minute live build review
+            </li>
+            <li class="tag">
+              <svg viewBox="0 0 16 16" aria-hidden="true">
+                <path d="M6.5 10.5l-2-2 1.4-1.4 0.6 0.59 3.6-3.59L11.5 5.5z" fill="currentColor"></path>
+              </svg>
+              Compliance &amp; security Q&amp;A
+            </li>
+            <li class="tag">
+              <svg viewBox="0 0 16 16" aria-hidden="true">
+                <path d="M6.5 10.5l-2-2 1.4-1.4 0.6 0.59 3.6-3.59L11.5 5.5z" fill="currentColor"></path>
+              </svg>
+              Rollout roadmap and success metrics
+            </li>
+          </ul>
+        </div>
+        <form class="lead-form" data-validate="true" data-success-message="Thanks! A specialist will reach out within 24 hours." novalidate>
+          <div>
+            <label for="demo-name">Full name</label>
+            <input id="demo-name" type="text" name="name" placeholder="Jordan Lee" required>
+          </div>
+          <div>
+            <label for="demo-email">Work email</label>
+            <input id="demo-email" type="email" name="email" placeholder="you@company.com" required>
+          </div>
+          <div>
+            <label for="demo-company">Organization</label>
+            <input id="demo-company" type="text" name="company" placeholder="Company name" required>
+          </div>
+          <div>
+            <label for="demo-usecase">Primary use case</label>
+            <textarea id="demo-usecase" name="usecase" placeholder="Describe the workflows you want to augment" required></textarea>
+          </div>
+          <div>
+            <label for="demo-regions">Regions served</label>
+            <input id="demo-regions" type="text" name="regions" placeholder="e.g., US, EU, APAC" required>
+          </div>
+          <div>
+            <label for="demo-timeline">Target launch timeline</label>
+            <input id="demo-timeline" type="text" name="timeline" placeholder="Example: Pilot in Q3" required>
+          </div>
+          <p class="form-message" aria-live="polite"></p>
+          <button class="btn btn-primary" type="submit">Submit request</button>
+        </form>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container final-cta">
+        <h2>See how Agent Programming Tool powers your next web app</h2>
+        <p>Our engineers will co-design your orchestrations, configure guardrails, and deliver the dashboards needed to manage every agent interaction.</p>
+        <div class="nav-actions" style="justify-content:center; gap:1rem; flex-wrap:wrap;">
+          <a class="btn btn-primary" href="services.html">Explore deployment packages</a>
+          <a class="btn btn-ghost" href="contact.html">Message our team</a>
+        </div>
+      </div>
+    </section>
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-brand">
+          <a class="logo" href="index.html">
+            <svg aria-hidden="true" viewBox="0 0 48 48">
+              <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+              <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+              <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+            </svg>
+            <span>Agent Web Applications</span>
+          </a>
+          <p>We design, govern, and scale AI agent web apps for regulated teams that need measurable outcomes.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="btn btn-ghost">Netshow.AI</a>
+        </div>
+        <div>
+          <h3 class="sr-only">Quick Links</h3>
+          <div class="footer-links">
+            <a href="index.html">Home</a>
+            <a href="about.html">About</a>
+            <a href="services.html">Services</a>
+            <a href="blog.html">Blog</a>
+            <a href="faq.html">FAQ</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Legal Links</h3>
+          <div class="footer-links">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="disclosure.html">Disclosure</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Contact Information</h3>
+          <div class="footer-links">
+            <span>99 Market Street, Suite 540<br>San Francisco, CA 94105</span>
+            <a href="tel:+14155550123">+1 (415) 555-0123</a>
+            <a href="mailto:hello@agentwebapplications.com">hello@agentwebapplications.com</a>
+            <div class="social-links" aria-label="Social media">
+              <a href="https://www.facebook.com" aria-label="Facebook">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M14 8h2V5h-2c-2.2 0-4 1.8-4 4v2H8v3h2v7h3v-7h3l1-3h-4V9c0-.6.4-1 1-1z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.twitter.com" aria-label="X">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4 4l7.5 7.5L4 20h3.5l5.2-6 5.1 6H20l-7.4-8L20 4h-3.4l-4.7 5.5L7.2 4z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.instagram.com" aria-label="Instagram">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <rect x="3" y="3" width="18" height="18" rx="5" ry="5" fill="none" stroke="currentColor" stroke-width="2"></rect>
+                  <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="2"></circle>
+                  <circle cx="17" cy="7" r="1.5" fill="currentColor"></circle>
+                </svg>
+              </a>
+              <a href="https://www.linkedin.com" aria-label="LinkedIn">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4.98 3.5a2 2 0 1 1 0 4 2 2 0 0 1 0-4zM4 8.75h2.1V20H4zM9.25 8.75H11.3v1.54h.03c.29-.55 1-1.13 2.06-1.13 2.2 0 2.6 1.45 2.6 3.33V20h-2.1v-6c0-1.43-.03-3.26-1.99-3.26-1.99 0-2.3 1.55-2.3 3.15V20H9.25z" fill="currentColor"></path>
+                </svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© 2025 Agent Web Applications. All Rights Reserved.</span>
+        <span>Built for intelligent orchestration of web-based AI agents.</span>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/agentwebapplications.com/disclosure.html
+++ b/agentwebapplications.com/disclosure.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Responsible AI Disclosure | Agent Web Applications</title>
+  <meta name="description" content="Responsible AI disclosure describing how Agent Web Applications approaches transparency and limitations.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+  <script defer src="js/script.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <div id="login" class="sr-only" aria-hidden="true">Client portal access for subscribers is handled through our secure workspace.</div>
+  <header class="site-header" role="banner">
+    <div class="container nav-wrapper">
+      <a class="logo" href="index.html" aria-label="Agent Web Applications home">
+        <svg aria-hidden="true" viewBox="0 0 48 48">
+          <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+          <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+          <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+        </svg>
+        <span>Agent Web Applications</span>
+      </a>
+      <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+      <nav class="primary-nav" id="primary-navigation" aria-label="Primary navigation">
+        <ul class="nav-list">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li class="nav-dropdown">
+            <button class="dropdown-toggle" type="button" data-dropdown-toggle aria-expanded="false" aria-haspopup="true">
+              Services
+              <svg aria-hidden="true" viewBox="0 0 16 16">
+                <path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+            <ul class="dropdown-menu" data-dropdown-menu>
+              <li><a href="services.html#tier-basic">Launch Pad (Basic)</a></li>
+              <li><a href="services.html#tier-pro">Workflow Studio (Pro)</a></li>
+              <li><a href="services.html#tier-enterprise">Co-Pilot Cloud (Enterprise)</a></li>
+            </ul>
+          </li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <div class="nav-actions">
+        <a class="btn btn-secondary" href="#login">Login</a>
+        <a class="btn btn-primary" href="demo.html">Request a Demo</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
+          <span aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img">
+              <path d="M12 4a1 1 0 0 1 1 1v2.06a1 1 0 0 1-2 0V5a1 1 0 0 1 1-1zm6.36 3.64a1 1 0 0 1 0 1.41l-1.46 1.46a1 1 0 0 1-1.41-1.41l1.46-1.46a1 1 0 0 1 1.41 0zM19 11h2a1 1 0 0 1 0 2h-2a1 1 0 0 1 0-2zm-7 7a1 1 0 0 1 1-1h2.06a1 1 0 0 1 0 2H13a1 1 0 0 1-1-1zm-5.95-1.05a1 1 0 0 1 1.41 0l1.46 1.46a1 1 0 0 1-1.41 1.41l-1.46-1.46a1 1 0 0 1 0-1.41zM5 11a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2h2zm1.05-5.95a1 1 0 0 1 1.41 0l1.46 1.46A1 1 0 0 1 7.51 7.92L6.05 6.46a1 1 0 0 1 0-1.41z" fill="currentColor"></path>
+              <circle cx="12" cy="12" r="3" fill="currentColor"></circle>
+            </svg>
+          </span>
+          <span data-theme-label>Switch to dark mode</span>
+        </button>
+      </div>
+    </div>
+  </header>
+  <main id="main" class="section">
+    <div class="container">
+      <article class="legal">
+        <h1>Responsible AI Disclosure</h1>
+        <p>Updated January 2025</p>
+        <p>Agent Web Applications builds AI agent web apps that combine automation with human oversight. This disclosure explains how we approach transparency, limitations, and responsible use.</p>
+
+        <h2>Human-in-the-loop design</h2>
+        <p>Our solutions are built to augment—not replace—critical human judgment. Every deployment includes escalation paths, manual review options, and consent logging to ensure operators remain accountable.</p>
+
+        <h2>Model sources and training data</h2>
+        <p>We orchestrate third-party and client-provided models. We do not train foundation models on customer data. When fine-tuning is required, we do so within the client’s controlled environment using approved datasets.</p>
+
+        <h2>Limitations and accuracy</h2>
+        <p>AI systems can produce incorrect or biased outputs. We mitigate this risk through guardrails, monitoring, and human validation, but outcomes are not guaranteed. Clients must review outputs before acting on them in high-stakes contexts.</p>
+
+        <h2>Security and compliance</h2>
+        <p>We implement industry-standard security practices and follow relevant regulations (HIPAA, SOC 2, ISO 27001) when providing managed services. Clients are responsible for meeting additional compliance requirements specific to their industries.</p>
+
+        <h2>Incident response</h2>
+        <p>If a security or compliance incident occurs, we will promptly notify affected clients, investigate the root cause, and work together on remediation steps according to contractual obligations.</p>
+
+        <h2>Feedback and concerns</h2>
+        <p>If you have concerns about model behavior, bias, or transparency, contact responsibleai@agentwebapplications.com. We review all reports and integrate learnings into our product roadmap.</p>
+      </article>
+    </div>
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-brand">
+          <a class="logo" href="index.html">
+            <svg aria-hidden="true" viewBox="0 0 48 48">
+              <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+              <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+              <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+            </svg>
+            <span>Agent Web Applications</span>
+          </a>
+          <p>We design, govern, and scale AI agent web apps for regulated teams that need measurable outcomes.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="btn btn-ghost">Netshow.AI</a>
+        </div>
+        <div>
+          <h3 class="sr-only">Quick Links</h3>
+          <div class="footer-links">
+            <a href="index.html">Home</a>
+            <a href="about.html">About</a>
+            <a href="services.html">Services</a>
+            <a href="blog.html">Blog</a>
+            <a href="faq.html">FAQ</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Legal Links</h3>
+          <div class="footer-links">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="disclosure.html" aria-current="page">Disclosure</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Contact Information</h3>
+          <div class="footer-links">
+            <span>99 Market Street, Suite 540<br>San Francisco, CA 94105</span>
+            <a href="tel:+14155550123">+1 (415) 555-0123</a>
+            <a href="mailto:hello@agentwebapplications.com">hello@agentwebapplications.com</a>
+            <div class="social-links" aria-label="Social media">
+              <a href="https://www.facebook.com" aria-label="Facebook">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M14 8h2V5h-2c-2.2 0-4 1.8-4 4v2H8v3h2v7h3v-7h3l1-3h-4V9c0-.6.4-1 1-1z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.twitter.com" aria-label="X">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4 4l7.5 7.5L4 20h3.5l5.2-6 5.1 6H20l-7.4-8L20 4h-3.4l-4.7 5.5L7.2 4z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.instagram.com" aria-label="Instagram">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <rect x="3" y="3" width="18" height="18" rx="5" ry="5" fill="none" stroke="currentColor" stroke-width="2"></rect>
+                  <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="2"></circle>
+                  <circle cx="17" cy="7" r="1.5" fill="currentColor"></circle>
+                </svg>
+              </a>
+              <a href="https://www.linkedin.com" aria-label="LinkedIn">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4.98 3.5a2 2 0 1 1 0 4 2 2 0 0 1 0-4zM4 8.75h2.1V20H4zM9.25 8.75H11.3v1.54h.03c.29-.55 1-1.13 2.06-1.13 2.2 0 2.6 1.45 2.6 3.33V20h-2.1v-6c0-1.43-.03-3.26-1.99-3.26-1.99 0-2.3 1.55-2.3 3.15V20H9.25z" fill="currentColor"></path>
+                </svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© 2025 Agent Web Applications. All Rights Reserved.</span>
+        <span>Built for intelligent orchestration of web-based AI agents.</span>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/agentwebapplications.com/faq.html
+++ b/agentwebapplications.com/faq.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>FAQ | Agent Web Applications</title>
+  <meta name="description" content="Frequently asked questions about Agent Web Applications services, security, and onboarding.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+  <script defer src="js/script.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <div id="login" class="sr-only" aria-hidden="true">Client portal access for subscribers is handled through our secure workspace.</div>
+  <header class="site-header" role="banner">
+    <div class="container nav-wrapper">
+      <a class="logo" href="index.html" aria-label="Agent Web Applications home">
+        <svg aria-hidden="true" viewBox="0 0 48 48">
+          <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+          <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+          <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+        </svg>
+        <span>Agent Web Applications</span>
+      </a>
+      <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+      <nav class="primary-nav" id="primary-navigation" aria-label="Primary navigation">
+        <ul class="nav-list">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li class="nav-dropdown">
+            <button class="dropdown-toggle" type="button" data-dropdown-toggle aria-expanded="false" aria-haspopup="true">
+              Services
+              <svg aria-hidden="true" viewBox="0 0 16 16">
+                <path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+            <ul class="dropdown-menu" data-dropdown-menu>
+              <li><a href="services.html#tier-basic">Launch Pad (Basic)</a></li>
+              <li><a href="services.html#tier-pro">Workflow Studio (Pro)</a></li>
+              <li><a href="services.html#tier-enterprise">Co-Pilot Cloud (Enterprise)</a></li>
+            </ul>
+          </li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="faq.html" aria-current="page">FAQ</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <div class="nav-actions">
+        <a class="btn btn-secondary" href="#login">Login</a>
+        <a class="btn btn-primary" href="demo.html">Request a Demo</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
+          <span aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img">
+              <path d="M12 4a1 1 0 0 1 1 1v2.06a1 1 0 0 1-2 0V5a1 1 0 0 1 1-1zm6.36 3.64a1 1 0 0 1 0 1.41l-1.46 1.46a1 1 0 0 1-1.41-1.41l1.46-1.46a1 1 0 0 1 1.41 0zM19 11h2a1 1 0 0 1 0 2h-2a1 1 0 0 1 0-2zm-7 7a1 1 0 0 1 1-1h2.06a1 1 0 0 1 0 2H13a1 1 0 0 1-1-1zm-5.95-1.05a1 1 0 0 1 1.41 0l1.46 1.46a1 1 0 0 1-1.41 1.41l-1.46-1.46a1 1 0 0 1 0-1.41zM5 11a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2h2zm1.05-5.95a1 1 0 0 1 1.41 0l1.46 1.46A1 1 0 0 1 7.51 7.92L6.05 6.46a1 1 0 0 1 0-1.41z" fill="currentColor"></path>
+              <circle cx="12" cy="12" r="3" fill="currentColor"></circle>
+            </svg>
+          </span>
+          <span data-theme-label>Switch to dark mode</span>
+        </button>
+      </div>
+    </div>
+  </header>
+  <main id="main" class="section">
+    <div class="container">
+      <div class="section-header">
+        <h1>Frequently asked questions</h1>
+        <p>Answers to common questions about our services, security posture, and onboarding experience.</p>
+      </div>
+      <div class="faq-list">
+        <details>
+          <summary>How quickly can you launch an agent web application?</summary>
+          <p>Most clients see their first production-ready agent web app in six weeks. The timeline includes discovery, guardrail design, development, and validation inside the Agent Programming Tool environment.</p>
+        </details>
+        <details>
+          <summary>Do you support on-premise or private cloud deployments?</summary>
+          <p>Yes. Our Co-Pilot Cloud tier includes VPC and on-premise options. We manage updates via signed containers and provide infrastructure-as-code templates aligned to your security controls.</p>
+        </details>
+        <details>
+          <summary>How do you keep regulated data safe?</summary>
+          <p>We implement strict data classification, encrypted storage, and redaction pipelines. Each deployment includes consent tracking, automated PHI detection, and human review workflows before data leaves approved boundaries.</p>
+        </details>
+        <details>
+          <summary>Can we integrate our own models?</summary>
+          <p>Absolutely. We support integrating approved foundation models, domain-tuned LLMs, or retrieval augmented systems. Our guardrail layer wraps every model call with policy checks.</p>
+        </details>
+        <details>
+          <summary>What happens after launch?</summary>
+          <p>We offer continuous improvement cycles that include telemetry reviews, prompt updates, and user feedback sessions. Clients receive quarterly reports summarizing adoption, compliance posture, and roadmap recommendations.</p>
+        </details>
+      </div>
+    </div>
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-brand">
+          <a class="logo" href="index.html">
+            <svg aria-hidden="true" viewBox="0 0 48 48">
+              <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+              <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+              <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+            </svg>
+            <span>Agent Web Applications</span>
+          </a>
+          <p>We design, govern, and scale AI agent web apps for regulated teams that need measurable outcomes.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="btn btn-ghost">Netshow.AI</a>
+        </div>
+        <div>
+          <h3 class="sr-only">Quick Links</h3>
+          <div class="footer-links">
+            <a href="index.html">Home</a>
+            <a href="about.html">About</a>
+            <a href="services.html">Services</a>
+            <a href="blog.html">Blog</a>
+            <a href="faq.html" aria-current="page">FAQ</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Legal Links</h3>
+          <div class="footer-links">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="disclosure.html">Disclosure</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Contact Information</h3>
+          <div class="footer-links">
+            <span>99 Market Street, Suite 540<br>San Francisco, CA 94105</span>
+            <a href="tel:+14155550123">+1 (415) 555-0123</a>
+            <a href="mailto:hello@agentwebapplications.com">hello@agentwebapplications.com</a>
+            <div class="social-links" aria-label="Social media">
+              <a href="https://www.facebook.com" aria-label="Facebook">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M14 8h2V5h-2c-2.2 0-4 1.8-4 4v2H8v3h2v7h3v-7h3l1-3h-4V9c0-.6.4-1 1-1z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.twitter.com" aria-label="X">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4 4l7.5 7.5L4 20h3.5l5.2-6 5.1 6H20l-7.4-8L20 4h-3.4l-4.7 5.5L7.2 4z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.instagram.com" aria-label="Instagram">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <rect x="3" y="3" width="18" height="18" rx="5" ry="5" fill="none" stroke="currentColor" stroke-width="2"></rect>
+                  <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="2"></circle>
+                  <circle cx="17" cy="7" r="1.5" fill="currentColor"></circle>
+                </svg>
+              </a>
+              <a href="https://www.linkedin.com" aria-label="LinkedIn">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4.98 3.5a2 2 0 1 1 0 4 2 2 0 0 1 0-4zM4 8.75h2.1V20H4zM9.25 8.75H11.3v1.54h.03c.29-.55 1-1.13 2.06-1.13 2.2 0 2.6 1.45 2.6 3.33V20h-2.1v-6c0-1.43-.03-3.26-1.99-3.26-1.99 0-2.3 1.55-2.3 3.15V20H9.25z" fill="currentColor"></path>
+                </svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© 2025 Agent Web Applications. All Rights Reserved.</span>
+        <span>Built for intelligent orchestration of web-based AI agents.</span>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/agentwebapplications.com/images/blog-card-1.svg
+++ b/agentwebapplications.com/images/blog-card-1.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="360" height="220" viewBox="0 0 360 220" role="img" aria-labelledby="title desc">
+  <title>Blog Illustration Placeholder</title>
+  <desc>Abstract gradient card for blog content.</desc>
+  <defs>
+    <linearGradient id="gradBlog1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3a3ad1" />
+      <stop offset="100%" stop-color="#1ab7c4" />
+    </linearGradient>
+  </defs>
+  <rect width="360" height="220" rx="28" fill="url(#gradBlog1)" />
+  <path d="M40 160c48-60 120-80 200-40s120-20 120-20v60H40z" fill="rgba(255,255,255,0.25)" />
+</svg>

--- a/agentwebapplications.com/images/blog-card-2.svg
+++ b/agentwebapplications.com/images/blog-card-2.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="360" height="220" viewBox="0 0 360 220" role="img" aria-labelledby="title desc">
+  <title>Blog Illustration Placeholder</title>
+  <desc>Abstract gradient card with diagonal pattern.</desc>
+  <defs>
+    <linearGradient id="gradBlog2" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#f87b56" />
+      <stop offset="100%" stop-color="#3a3ad1" />
+    </linearGradient>
+  </defs>
+  <rect width="360" height="220" rx="28" fill="url(#gradBlog2)" />
+  <g fill="rgba(255,255,255,0.22)">
+    <rect x="40" y="40" width="60" height="140" rx="16" />
+    <rect x="120" y="60" width="60" height="120" rx="16" />
+    <rect x="200" y="48" width="60" height="132" rx="16" />
+    <rect x="280" y="72" width="60" height="108" rx="16" />
+  </g>
+</svg>

--- a/agentwebapplications.com/images/blog-card-3.svg
+++ b/agentwebapplications.com/images/blog-card-3.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="360" height="220" viewBox="0 0 360 220" role="img" aria-labelledby="title desc">
+  <title>Blog Illustration Placeholder</title>
+  <desc>Abstract waves for blog artwork.</desc>
+  <defs>
+    <linearGradient id="gradBlog3" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1f2241" />
+      <stop offset="100%" stop-color="#3a3ad1" />
+    </linearGradient>
+  </defs>
+  <rect width="360" height="220" rx="28" fill="url(#gradBlog3)" />
+  <path d="M0 160c40-28 120-20 180 0s140 24 180 0v60H0z" fill="#f87b56" opacity="0.3" />
+</svg>

--- a/agentwebapplications.com/images/case-study-1.svg
+++ b/agentwebapplications.com/images/case-study-1.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="120" viewBox="0 0 200 120" role="img" aria-labelledby="title desc">
+  <title>Case Study Logo Placeholder</title>
+  <desc>Stylized shape for client logo.</desc>
+  <rect width="200" height="120" rx="20" fill="#e9ecff" />
+  <text x="50%" y="52%" text-anchor="middle" dominant-baseline="middle" font-family="'Poppins', Arial, sans-serif" font-size="26" font-weight="600" fill="#3a3ad1">DataLift</text>
+</svg>

--- a/agentwebapplications.com/images/case-study-2.svg
+++ b/agentwebapplications.com/images/case-study-2.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="120" viewBox="0 0 200 120" role="img" aria-labelledby="title desc">
+  <title>Case Study Logo Placeholder</title>
+  <desc>Stylized shape for client logo.</desc>
+  <rect width="200" height="120" rx="20" fill="#fdefe7" />
+  <text x="50%" y="52%" text-anchor="middle" dominant-baseline="middle" font-family="'Poppins', Arial, sans-serif" font-size="26" font-weight="600" fill="#f87b56">ClinicX</text>
+</svg>

--- a/agentwebapplications.com/images/case-study-3.svg
+++ b/agentwebapplications.com/images/case-study-3.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="120" viewBox="0 0 200 120" role="img" aria-labelledby="title desc">
+  <title>Case Study Logo Placeholder</title>
+  <desc>Stylized shape for client logo.</desc>
+  <rect width="200" height="120" rx="20" fill="#e6f8fa" />
+  <text x="50%" y="52%" text-anchor="middle" dominant-baseline="middle" font-family="'Poppins', Arial, sans-serif" font-size="26" font-weight="600" fill="#1ab7c4">OrbitOps</text>
+</svg>

--- a/agentwebapplications.com/images/demo-video.svg
+++ b/agentwebapplications.com/images/demo-video.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title>Product Demo Video Placeholder</title>
+  <desc>Placeholder graphic with play button.</desc>
+  <rect width="640" height="360" rx="32" fill="#1f2241" />
+  <rect x="40" y="40" width="560" height="280" rx="24" fill="#3a3ad1" opacity="0.85" />
+  <circle cx="320" cy="180" r="60" fill="#f87b56" opacity="0.9" />
+  <polygon points="304,150 356,180 304,210" fill="#fff" opacity="0.9" />
+</svg>

--- a/agentwebapplications.com/images/hero-illustration.svg
+++ b/agentwebapplications.com/images/hero-illustration.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="520" height="420" viewBox="0 0 520 420" role="img" aria-labelledby="title desc">
+  <title>Hero Illustration showing AI agents collaborating</title>
+  <desc>Stylized illustration of connected screens and AI avatars collaborating.</desc>
+  <rect width="520" height="420" rx="48" fill="#f6f2ff" />
+  <rect x="60" y="70" width="400" height="260" rx="32" fill="#3a3ad1" opacity="0.85" />
+  <rect x="96" y="110" width="180" height="120" rx="20" fill="#fff" opacity="0.85" />
+  <rect x="280" y="140" width="140" height="140" rx="28" fill="#1ab7c4" opacity="0.8" />
+  <circle cx="150" cy="170" r="28" fill="#3a3ad1" opacity="0.8" />
+  <circle cx="340" cy="190" r="36" fill="#f87b56" opacity="0.8" />
+  <circle cx="368" cy="260" r="18" fill="#fff" opacity="0.9" />
+  <circle cx="196" cy="226" r="18" fill="#fff" opacity="0.9" />
+  <path d="M178 182h40" stroke="#f87b56" stroke-width="8" stroke-linecap="round" opacity="0.8" />
+  <path d="M330 230h46" stroke="#fff" stroke-width="8" stroke-linecap="round" opacity="0.8" />
+  <path d="M220 140c24-36 72-36 96 0" stroke="#fff" stroke-width="8" stroke-linecap="round" fill="none" opacity="0.4" />
+</svg>

--- a/agentwebapplications.com/images/media-logo-1.svg
+++ b/agentwebapplications.com/images/media-logo-1.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="60" viewBox="0 0 140 60" role="img" aria-labelledby="title desc">
+  <title>Media Logo Placeholder</title>
+  <desc>Rounded rectangle with stylized initials.</desc>
+  <rect width="140" height="60" rx="12" fill="#e5e8ff" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="'Poppins', Arial, sans-serif" font-weight="600" font-size="20" fill="#3a3ad1">TechNow</text>
+</svg>

--- a/agentwebapplications.com/images/media-logo-2.svg
+++ b/agentwebapplications.com/images/media-logo-2.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="60" viewBox="0 0 140 60" role="img" aria-labelledby="title desc">
+  <title>Media Logo Placeholder</title>
+  <desc>Rounded rectangle with stylized initials.</desc>
+  <rect width="140" height="60" rx="12" fill="#fdefe7" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="'Poppins', Arial, sans-serif" font-weight="600" font-size="20" fill="#f87b56">AIWeek</text>
+</svg>

--- a/agentwebapplications.com/images/media-logo-3.svg
+++ b/agentwebapplications.com/images/media-logo-3.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="60" viewBox="0 0 140 60" role="img" aria-labelledby="title desc">
+  <title>Media Logo Placeholder</title>
+  <desc>Rounded rectangle with stylized initials.</desc>
+  <rect width="140" height="60" rx="12" fill="#e6f8fa" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="'Poppins', Arial, sans-serif" font-weight="600" font-size="20" fill="#1ab7c4">CloudLab</text>
+</svg>

--- a/agentwebapplications.com/images/media-logo-4.svg
+++ b/agentwebapplications.com/images/media-logo-4.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="140" height="60" viewBox="0 0 140 60" role="img" aria-labelledby="title desc">
+  <title>Media Logo Placeholder</title>
+  <desc>Rounded rectangle with stylized initials.</desc>
+  <rect width="140" height="60" rx="12" fill="#ede6ff" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="'Poppins', Arial, sans-serif" font-weight="600" font-size="20" fill="#1f2241">FutureNet</text>
+</svg>

--- a/agentwebapplications.com/images/product-insights.svg
+++ b/agentwebapplications.com/images/product-insights.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="200" viewBox="0 0 320 200" role="img" aria-labelledby="title desc">
+  <title>Analytics Insights Illustration Placeholder</title>
+  <desc>Graph-style shapes representing analytics.</desc>
+  <rect width="320" height="200" rx="24" fill="#e6f8fa" />
+  <polyline points="40,150 90,100 140,126 190,78 240,110 280,60" stroke="#1ab7c4" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+  <circle cx="90" cy="100" r="10" fill="#3a3ad1" />
+  <circle cx="190" cy="78" r="10" fill="#3a3ad1" />
+  <circle cx="280" cy="60" r="10" fill="#3a3ad1" />
+</svg>

--- a/agentwebapplications.com/images/product-kit.svg
+++ b/agentwebapplications.com/images/product-kit.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="200" viewBox="0 0 320 200" role="img" aria-labelledby="title desc">
+  <title>Product Illustration Placeholder</title>
+  <desc>Abstract representation of product toolkit.</desc>
+  <rect width="320" height="200" rx="24" fill="#f6f2ff" />
+  <rect x="48" y="48" width="224" height="120" rx="20" fill="#3a3ad1" opacity="0.8" />
+  <rect x="70" y="70" width="180" height="18" rx="9" fill="#fff" opacity="0.9" />
+  <rect x="70" y="104" width="140" height="18" rx="9" fill="#fff" opacity="0.7" />
+  <rect x="70" y="138" width="110" height="18" rx="9" fill="#fff" opacity="0.5" />
+</svg>

--- a/agentwebapplications.com/images/product-templates.svg
+++ b/agentwebapplications.com/images/product-templates.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="200" viewBox="0 0 320 200" role="img" aria-labelledby="title desc">
+  <title>Template Pack Illustration Placeholder</title>
+  <desc>Stacked cards representing templates.</desc>
+  <rect width="320" height="200" rx="24" fill="#e9ecff" />
+  <rect x="64" y="46" width="180" height="120" rx="16" fill="#1f2241" opacity="0.15" />
+  <rect x="88" y="64" width="180" height="120" rx="16" fill="#1f2241" opacity="0.25" />
+  <rect x="112" y="82" width="180" height="120" rx="16" fill="#3a3ad1" opacity="0.85" />
+  <rect x="140" y="110" width="124" height="18" rx="9" fill="#fff" opacity="0.8" />
+  <rect x="140" y="140" width="90" height="18" rx="9" fill="#fff" opacity="0.6" />
+</svg>

--- a/agentwebapplications.com/images/team-ava-1.svg
+++ b/agentwebapplications.com/images/team-ava-1.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="240" viewBox="0 0 240 240" role="img" aria-labelledby="title desc">
+  <title>Team Member Placeholder</title>
+  <desc>Abstract avatar illustration with warm gradient.</desc>
+  <defs>
+    <linearGradient id="gradTeam1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#dce1ff" />
+      <stop offset="100%" stop-color="#f6f2ff" />
+    </linearGradient>
+  </defs>
+  <rect width="240" height="240" rx="32" fill="url(#gradTeam1)" />
+  <circle cx="120" cy="92" r="52" fill="#3a3ad1" opacity="0.9" />
+  <rect x="62" y="150" width="116" height="66" rx="32" fill="#1f2241" opacity="0.75" />
+  <circle cx="100" cy="86" r="12" fill="#fff" opacity="0.85" />
+  <circle cx="140" cy="86" r="12" fill="#fff" opacity="0.85" />
+  <path d="M100 118c10 10 30 10 40 0" stroke="#fff" stroke-width="6" stroke-linecap="round" fill="none" opacity="0.7" />
+</svg>

--- a/agentwebapplications.com/images/team-ava-2.svg
+++ b/agentwebapplications.com/images/team-ava-2.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="240" viewBox="0 0 240 240" role="img" aria-labelledby="title desc">
+  <title>Team Member Placeholder</title>
+  <desc>Abstract avatar illustration in accent palette.</desc>
+  <defs>
+    <linearGradient id="gradTeam2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffe3d8" />
+      <stop offset="100%" stop-color="#fff5eb" />
+    </linearGradient>
+  </defs>
+  <rect width="240" height="240" rx="32" fill="url(#gradTeam2)" />
+  <circle cx="120" cy="92" r="52" fill="#f87b56" opacity="0.9" />
+  <rect x="62" y="150" width="116" height="66" rx="32" fill="#3a3ad1" opacity="0.75" />
+  <circle cx="100" cy="86" r="12" fill="#fff" opacity="0.85" />
+  <circle cx="140" cy="86" r="12" fill="#fff" opacity="0.85" />
+  <path d="M96 116c14 14 44 14 48 0" stroke="#fff" stroke-width="6" stroke-linecap="round" fill="none" opacity="0.7" />
+</svg>

--- a/agentwebapplications.com/images/team-ava-3.svg
+++ b/agentwebapplications.com/images/team-ava-3.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="240" viewBox="0 0 240 240" role="img" aria-labelledby="title desc">
+  <title>Team Member Placeholder</title>
+  <desc>Abstract avatar illustration with teal accents.</desc>
+  <defs>
+    <linearGradient id="gradTeam3" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#dcf3ff" />
+      <stop offset="100%" stop-color="#f0fbff" />
+    </linearGradient>
+  </defs>
+  <rect width="240" height="240" rx="32" fill="url(#gradTeam3)" />
+  <circle cx="120" cy="92" r="52" fill="#1ab7c4" opacity="0.9" />
+  <rect x="62" y="150" width="116" height="66" rx="32" fill="#1f2241" opacity="0.75" />
+  <circle cx="100" cy="86" r="12" fill="#fff" opacity="0.85" />
+  <circle cx="140" cy="86" r="12" fill="#fff" opacity="0.85" />
+  <path d="M100 122c12 10 28 10 40 0" stroke="#fff" stroke-width="6" stroke-linecap="round" fill="none" opacity="0.7" />
+</svg>

--- a/agentwebapplications.com/images/testimonial-1.svg
+++ b/agentwebapplications.com/images/testimonial-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title>Customer Portrait Placeholder</title>
+  <desc>Rounded square with abstract avatar.</desc>
+  <rect width="160" height="160" rx="28" fill="#e9ecff" />
+  <circle cx="80" cy="58" r="36" fill="#3a3ad1" opacity="0.85" />
+  <rect x="42" y="96" width="76" height="44" rx="22" fill="#f87b56" opacity="0.7" />
+</svg>

--- a/agentwebapplications.com/images/testimonial-2.svg
+++ b/agentwebapplications.com/images/testimonial-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title>Customer Portrait Placeholder</title>
+  <desc>Rounded square with abstract avatar in teal.</desc>
+  <rect width="160" height="160" rx="28" fill="#dcf3ff" />
+  <circle cx="80" cy="58" r="36" fill="#1ab7c4" opacity="0.9" />
+  <rect x="42" y="96" width="76" height="44" rx="22" fill="#1f2241" opacity="0.6" />
+</svg>

--- a/agentwebapplications.com/images/testimonial-3.svg
+++ b/agentwebapplications.com/images/testimonial-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160" role="img" aria-labelledby="title desc">
+  <title>Customer Portrait Placeholder</title>
+  <desc>Rounded square with abstract avatar in dark blue.</desc>
+  <rect width="160" height="160" rx="28" fill="#f6f2ff" />
+  <circle cx="80" cy="58" r="36" fill="#1f2241" opacity="0.9" />
+  <rect x="42" y="96" width="76" height="44" rx="22" fill="#f87b56" opacity="0.6" />
+</svg>

--- a/agentwebapplications.com/index.html
+++ b/agentwebapplications.com/index.html
@@ -1,0 +1,360 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Agent Web Applications | Compliance-Ready AI Agent Web Apps</title>
+  <meta name="description" content="Agent Web Applications turns complex, regulated workflows into compliant AI agent web apps with human-in-the-loop oversight, observability, and industry-grade security.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+  <script defer src="js/script.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <div id="login" class="sr-only" aria-hidden="true">Client portal access for subscribers is handled through our secure workspace.</div>
+  <header class="site-header" role="banner">
+    <div class="container nav-wrapper">
+      <a class="logo" href="index.html" aria-label="Agent Web Applications home">
+        <svg aria-hidden="true" viewBox="0 0 48 48">
+          <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+          <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+          <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+        </svg>
+        <span>Agent Web Applications</span>
+      </a>
+      <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+      <nav class="primary-nav" id="primary-navigation" aria-label="Primary navigation">
+        <ul class="nav-list">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li class="nav-dropdown">
+            <button class="dropdown-toggle" type="button" data-dropdown-toggle aria-expanded="false" aria-haspopup="true">
+              Services
+              <svg aria-hidden="true" viewBox="0 0 16 16">
+                <path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+            <ul class="dropdown-menu" data-dropdown-menu>
+              <li><a href="services.html#tier-basic">Launch Pad (Basic)</a></li>
+              <li><a href="services.html#tier-pro">Workflow Studio (Pro)</a></li>
+              <li><a href="services.html#tier-enterprise">Co-Pilot Cloud (Enterprise)</a></li>
+            </ul>
+          </li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <div class="nav-actions">
+        <a class="btn btn-secondary" href="#login">Login</a>
+        <a class="btn btn-primary" href="demo.html">Request a Demo</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
+          <span aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img">
+              <path d="M12 4a1 1 0 0 1 1 1v2.06a1 1 0 0 1-2 0V5a1 1 0 0 1 1-1zm6.36 3.64a1 1 0 0 1 0 1.41l-1.46 1.46a1 1 0 0 1-1.41-1.41l1.46-1.46a1 1 0 0 1 1.41 0zM19 11h2a1 1 0 0 1 0 2h-2a1 1 0 0 1 0-2zm-7 7a1 1 0 0 1 1-1h2.06a1 1 0 0 1 0 2H13a1 1 0 0 1-1-1zm-5.95-1.05a1 1 0 0 1 1.41 0l1.46 1.46a1 1 0 0 1-1.41 1.41l-1.46-1.46a1 1 0 0 1 0-1.41zM5 11a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2h2zm1.05-5.95a1 1 0 0 1 1.41 0l1.46 1.46A1 1 0 0 1 7.51 7.92L6.05 6.46a1 1 0 0 1 0-1.41z" fill="currentColor"></path>
+              <circle cx="12" cy="12" r="3" fill="currentColor"></circle>
+            </svg>
+          </span>
+          <span data-theme-label>Switch to dark mode</span>
+        </button>
+      </div>
+    </div>
+  </header>
+  <main id="main">
+    <section class="hero section">
+      <div class="container hero-grid">
+        <div class="hero-content">
+          <span class="hero-label">Business Idea: AI Orchestration for Regulated Teams</span>
+          <h1>Launch compliance-ready agent web apps in a matter of days.</h1>
+          <p>Agent Web Applications transforms your institutional knowledge into secure, human-guided AI agent web applications that are easy for operations teams to use and easy for legal to approve. From blueprinting to monitoring, we own every step so you can deploy confidently.</p>
+          <form class="hero-form" data-validate="true" data-success-message="Thanks! We'll schedule your onboarding session within one business day." novalidate>
+            <label class="sr-only" for="hero-email">Work Email</label>
+            <input id="hero-email" type="email" name="email" placeholder="Enter your work email" required>
+            <button class="btn btn-primary" type="submit">Get Started</button>
+            <p class="form-message" aria-live="polite"></p>
+          </form>
+          <a class="hero-link" href="https://calendly.com/netshow/discovery-call" target="_blank" rel="noopener">Book Your Call Now</a>
+          <div class="stats-grid" aria-label="Key company metrics">
+            <div class="stat-card">
+              <h3>72 hrs</h3>
+              <p>Average time to ship a pilot agent web app.</p>
+            </div>
+            <div class="stat-card">
+              <h3>98%</h3>
+              <p>Client compliance score after audit-readiness review.</p>
+            </div>
+            <div class="stat-card">
+              <h3>+43%</h3>
+              <p>Operational throughput increase reported by customers.</p>
+            </div>
+          </div>
+        </div>
+        <div class="hero-media" aria-hidden="true">
+          <img src="images/hero-illustration.svg" alt="Illustration of AI agents collaborating in a web application workspace.">
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="how-it-works">
+      <div class="container">
+        <div class="section-header">
+          <h2>How it works</h2>
+          <p>We engineered a repeatable, insight-driven process so your AI agents launch quickly, stay compliant, and evolve with your business requirements.</p>
+        </div>
+        <div class="how-grid">
+          <article class="how-card">
+            <svg viewBox="0 0 64 64" role="img" aria-label="Discovery">
+              <rect width="64" height="64" rx="16" fill="var(--color-primary-soft)"></rect>
+              <path d="M20 22h24M20 32h24M20 42h18" stroke="var(--color-primary)" stroke-width="4" stroke-linecap="round"></path>
+            </svg>
+            <h3>1. Diagnose the workflow</h3>
+            <p>We map each decision, document, and escalation path during a design sprint to create a precise agent choreography blueprint.</p>
+          </article>
+          <article class="how-card">
+            <svg viewBox="0 0 64 64" role="img" aria-label="Compose">
+              <rect width="64" height="64" rx="16" fill="var(--color-accent-soft)"></rect>
+              <path d="M20 44L44 20" stroke="var(--color-accent)" stroke-width="4" stroke-linecap="round"></path>
+              <circle cx="24" cy="24" r="6" fill="var(--color-accent)"></circle>
+              <circle cx="40" cy="40" r="10" fill="var(--color-accent)" opacity="0.6"></circle>
+            </svg>
+            <h3>2. Compose guided agent experiences</h3>
+            <p>We assemble modular agent widgets, guardrails, and UI components to deliver a branded web experience your team actually trusts.</p>
+          </article>
+          <article class="how-card">
+            <svg viewBox="0 0 64 64" role="img" aria-label="Launch">
+              <rect width="64" height="64" rx="16" fill="var(--color-primary-soft)"></rect>
+              <path d="M32 16l12 12-12 20-12-20z" fill="var(--color-primary)"></path>
+              <path d="M20 48h24" stroke="var(--color-primary)" stroke-width="4" stroke-linecap="round"></path>
+            </svg>
+            <h3>3. Launch, observe, and iterate</h3>
+            <p>Real-time analytics, consent logging, and update cadences keep every agent app measurable and improvable.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="features">
+      <div class="container">
+        <div class="section-header">
+          <h2>Enterprise control with startup speed</h2>
+          <p>Agent Web Applications delivers the safety, integrations, and governance you expect with the agility your teams need to experiment.</p>
+        </div>
+        <div class="features-grid">
+          <article class="feature-card">
+            <svg viewBox="0 0 48 48" role="img" aria-label="Blueprints">
+              <rect width="48" height="48" rx="14" fill="var(--color-primary-soft)"></rect>
+              <path d="M16 34V14h16v20" stroke="var(--color-primary)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none"></path>
+              <path d="M16 24h16" stroke="var(--color-accent)" stroke-width="3" stroke-linecap="round"></path>
+            </svg>
+            <h3>Domain-specific agent blueprints</h3>
+            <p>Ready-to-tailor templates for healthcare, financial services, field operations, and energy compliance.</p>
+          </article>
+          <article class="feature-card">
+            <svg viewBox="0 0 48 48" role="img" aria-label="Guardrails">
+              <rect width="48" height="48" rx="14" fill="var(--color-accent-soft)"></rect>
+              <path d="M24 12l12 6v10c0 7.2-5.6 10.8-12 14-6.4-3.2-12-6.8-12-14V18z" fill="var(--color-accent)" opacity="0.8"></path>
+              <path d="M18 22h12" stroke="#fff" stroke-width="3" stroke-linecap="round"></path>
+            </svg>
+            <h3>Policy-aware guardrails</h3>
+            <p>Dynamic prompt filtering, consent capture, and human approval checkpoints tuned to each regulation.</p>
+          </article>
+          <article class="feature-card">
+            <svg viewBox="0 0 48 48" role="img" aria-label="Observability">
+              <rect width="48" height="48" rx="14" fill="var(--color-primary-soft)"></rect>
+              <polyline points="12 30 20 22 28 28 36 18" fill="none" stroke="var(--color-primary)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"></polyline>
+              <circle cx="20" cy="22" r="3" fill="var(--color-primary)"></circle>
+              <circle cx="36" cy="18" r="4" fill="var(--color-accent)"></circle>
+            </svg>
+            <h3>Full-stack observability</h3>
+            <p>Session replays, redaction logs, and KPI dashboards keep every agent action auditable.</p>
+          </article>
+          <article class="feature-card">
+            <svg viewBox="0 0 48 48" role="img" aria-label="Integrations">
+              <rect width="48" height="48" rx="14" fill="var(--color-accent-soft)"></rect>
+              <path d="M16 18h16v12H16z" fill="var(--color-accent)" opacity="0.6"></path>
+              <path d="M10 24h28" stroke="var(--color-accent)" stroke-width="3" stroke-linecap="round"></path>
+              <circle cx="16" cy="24" r="4" fill="var(--color-primary)"></circle>
+              <circle cx="32" cy="24" r="4" fill="var(--color-primary)"></circle>
+            </svg>
+            <h3>Deep system integrations</h3>
+            <p>Connect agents to your EMR, CRM, or proprietary knowledge base without exposing sensitive data.</p>
+          </article>
+          <article class="feature-card">
+            <svg viewBox="0 0 48 48" role="img" aria-label="Human oversight">
+              <rect width="48" height="48" rx="14" fill="var(--color-primary-soft)"></rect>
+              <circle cx="18" cy="20" r="6" fill="var(--color-primary)"></circle>
+              <circle cx="30" cy="28" r="6" fill="var(--color-accent)"></circle>
+              <path d="M12 36c2-6 8-8 12-8s10 2 12 8" fill="none" stroke="var(--color-primary)" stroke-width="3" stroke-linecap="round"></path>
+            </svg>
+            <h3>Human-in-the-loop escalation</h3>
+            <p>Route complex decisions to subject matter experts via review queues and Slack or Teams notifications.</p>
+          </article>
+          <article class="feature-card">
+            <svg viewBox="0 0 48 48" role="img" aria-label="Compliance">
+              <rect width="48" height="48" rx="14" fill="var(--color-accent-soft)"></rect>
+              <path d="M24 12l10 6v12l-10 6-10-6V18z" fill="var(--color-accent)"></path>
+              <path d="M20 24l3 4 5-6" stroke="#fff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+            <h3>Audit-ready binder</h3>
+            <p>Generate regulator-friendly documentation with every iteration of your agent experience.</p>
+          </article>
+          <article class="feature-card">
+            <svg viewBox="0 0 48 48" role="img" aria-label="Scalability">
+              <rect width="48" height="48" rx="14" fill="var(--color-primary-soft)"></rect>
+              <path d="M14 34h6V18h-6zm7 0h6V12h-6zm7 0h6V24h-6z" fill="var(--color-primary)"></path>
+              <path d="M14 14l10-4 10 4" stroke="var(--color-accent)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"></path>
+            </svg>
+            <h3>Elastic deployment options</h3>
+            <p>Launch on our managed cloud, your VPC, or hybrid edge environments with equal ease.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section testimonials" id="testimonials">
+      <div class="container">
+        <div class="section-header">
+          <h2>Teams trust Agent Web Applications</h2>
+          <p>From regional hospitals to aerospace manufacturers, customers rely on our agent-first approach to unlock new efficiencies.</p>
+        </div>
+        <div class="testimonials-grid">
+          <article class="testimonial-card">
+            <div class="testimonial-head">
+              <img src="images/testimonial-1.svg" alt="Portrait of Maya Patel">
+              <div>
+                <strong>Maya Patel</strong>
+                <p>Chief Innovation Officer, Horizon Clinics</p>
+              </div>
+            </div>
+            <p>“We replaced a 42-step intake checklist with an Agent Web Application that guides nurses in real time. Audit preparation that once took weeks now happens automatically.”</p>
+            <cite>Horizon Clinics</cite>
+          </article>
+          <article class="testimonial-card">
+            <div class="testimonial-head">
+              <img src="images/testimonial-2.svg" alt="Portrait of Aaron Lewis">
+              <div>
+                <strong>Aaron Lewis</strong>
+                <p>Director of Product, Orbit Freight</p>
+              </div>
+            </div>
+            <p>“Their guardrails meant our safety team could sign off on AI guidance without hesitation. Our dispatchers now resolve complex shipments 35% faster.”</p>
+            <cite>Orbit Freight</cite>
+          </article>
+          <article class="testimonial-card">
+            <div class="testimonial-head">
+              <img src="images/testimonial-3.svg" alt="Portrait of Elena Romero">
+              <div>
+                <strong>Elena Romero</strong>
+                <p>VP of Operations, NorthBridge Energy</p>
+              </div>
+            </div>
+            <p>“Within three weeks we had a production-ready compliance companion that captured field logs, validated them, and synced with our OT data warehouse.”</p>
+            <cite>NorthBridge Energy</cite>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="featured-in">
+      <div class="container">
+        <div class="section-header">
+          <h2>Featured in</h2>
+          <p>Industry analysts and publications covering responsible AI and workflow automation regularly highlight our approach.</p>
+        </div>
+        <div class="featured-logos">
+          <img src="images/media-logo-1.svg" alt="TechNow magazine logo">
+          <img src="images/media-logo-2.svg" alt="AIWeek news logo">
+          <img src="images/media-logo-3.svg" alt="CloudLab research network logo">
+          <img src="images/media-logo-4.svg" alt="FutureNet innovation journal logo">
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container final-cta">
+        <h2>Ready to orchestrate your next AI agent web app?</h2>
+        <p>Join teams that ship reliable agent experiences without sacrificing oversight. Explore the services catalog or book a tailored walkthrough.</p>
+        <div class="nav-actions" style="justify-content:center; flex-wrap:wrap; gap:1rem;">
+          <a class="btn btn-primary" href="services.html">Explore Services</a>
+          <a class="btn btn-ghost" href="demo.html">See the demo flow</a>
+        </div>
+      </div>
+    </section>
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-brand">
+          <a class="logo" href="index.html">
+            <svg aria-hidden="true" viewBox="0 0 48 48">
+              <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+              <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+              <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+            </svg>
+            <span>Agent Web Applications</span>
+          </a>
+          <p>We design, govern, and scale AI agent web apps for regulated teams that need measurable outcomes.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="btn btn-ghost">Netshow.AI</a>
+        </div>
+        <div>
+          <h3 class="sr-only">Quick Links</h3>
+          <div class="footer-links">
+            <a href="index.html">Home</a>
+            <a href="about.html">About</a>
+            <a href="services.html">Services</a>
+            <a href="blog.html">Blog</a>
+            <a href="faq.html">FAQ</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Legal Links</h3>
+          <div class="footer-links">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="disclosure.html">Disclosure</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Contact Information</h3>
+          <div class="footer-links">
+            <span>99 Market Street, Suite 540<br>San Francisco, CA 94105</span>
+            <a href="tel:+14155550123">+1 (415) 555-0123</a>
+            <a href="mailto:hello@agentwebapplications.com">hello@agentwebapplications.com</a>
+            <div class="social-links" aria-label="Social media">
+              <a href="https://www.facebook.com" aria-label="Facebook">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M14 8h2V5h-2c-2.2 0-4 1.8-4 4v2H8v3h2v7h3v-7h3l1-3h-4V9c0-.6.4-1 1-1z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.twitter.com" aria-label="X">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4 4l7.5 7.5L4 20h3.5l5.2-6 5.1 6H20l-7.4-8L20 4h-3.4l-4.7 5.5L7.2 4z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.instagram.com" aria-label="Instagram">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <rect x="3" y="3" width="18" height="18" rx="5" ry="5" fill="none" stroke="currentColor" stroke-width="2"></rect>
+                  <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="2"></circle>
+                  <circle cx="17" cy="7" r="1.5" fill="currentColor"></circle>
+                </svg>
+              </a>
+              <a href="https://www.linkedin.com" aria-label="LinkedIn">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4.98 3.5a2 2 0 1 1 0 4 2 2 0 0 1 0-4zM4 8.75h2.1V20H4zM9.25 8.75H11.3v1.54h.03c.29-.55 1-1.13 2.06-1.13 2.2 0 2.6 1.45 2.6 3.33V20h-2.1v-6c0-1.43-.03-3.26-1.99-3.26-1.99 0-2.3 1.55-2.3 3.15V20H9.25z" fill="currentColor"></path>
+                </svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© 2025 Agent Web Applications. All Rights Reserved.</span>
+        <span>Built for intelligent orchestration of web-based AI agents.</span>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/agentwebapplications.com/js/script.js
+++ b/agentwebapplications.com/js/script.js
@@ -1,0 +1,162 @@
+// Agent Web Applications shared interactions
+// Handles theme persistence, navigation behavior, dropdowns, and form validation.
+document.addEventListener('DOMContentLoaded', () => {
+  const root = document.documentElement;
+  const themeToggle = document.querySelector('[data-theme-toggle]');
+  const themeLabel = document.querySelector('[data-theme-label]');
+  const storedTheme = localStorage.getItem('awa-theme');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+
+  const applyTheme = (theme) => {
+    const normalized = theme === 'dark' ? 'dark' : 'light';
+    root.setAttribute('data-theme', normalized);
+    localStorage.setItem('awa-theme', normalized);
+    if (themeLabel) {
+      themeLabel.textContent = normalized === 'dark' ? 'Switch to light mode' : 'Switch to dark mode';
+    }
+    if (themeToggle) {
+      themeToggle.setAttribute('aria-pressed', normalized === 'dark');
+    }
+  };
+
+  if (storedTheme) {
+    applyTheme(storedTheme);
+  } else if (prefersDark.matches) {
+    applyTheme('dark');
+  }
+
+  prefersDark.addEventListener('change', (event) => {
+    if (!storedTheme) {
+      applyTheme(event.matches ? 'dark' : 'light');
+    }
+  });
+
+  if (themeToggle) {
+    themeToggle.addEventListener('click', () => {
+      const current = root.getAttribute('data-theme');
+      applyTheme(current === 'dark' ? 'light' : 'dark');
+    });
+  }
+
+  const menuToggle = document.querySelector('[data-menu-toggle]');
+  const primaryNav = document.querySelector('.primary-nav');
+  const dropdownToggle = document.querySelector('[data-dropdown-toggle]');
+  const dropdownMenu = document.querySelector('[data-dropdown-menu]');
+
+  const closeMenu = () => {
+    if (primaryNav && primaryNav.classList.contains('open')) {
+      primaryNav.classList.remove('open');
+      if (menuToggle) {
+        menuToggle.setAttribute('aria-expanded', 'false');
+      }
+    }
+  };
+
+  const closeDropdown = () => {
+    if (dropdownMenu && dropdownMenu.classList.contains('show')) {
+      dropdownMenu.classList.remove('show');
+      dropdownToggle?.setAttribute('aria-expanded', 'false');
+    }
+  };
+
+  if (menuToggle && primaryNav) {
+    menuToggle.addEventListener('click', () => {
+      const isOpen = primaryNav.classList.toggle('open');
+      menuToggle.setAttribute('aria-expanded', String(isOpen));
+      if (isOpen) {
+        primaryNav.querySelector('a, button')?.focus();
+      }
+    });
+
+    primaryNav.addEventListener('click', (event) => {
+      if (event.target instanceof HTMLElement && event.target.tagName === 'A') {
+        closeMenu();
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closeMenu();
+        closeDropdown();
+      }
+    });
+  }
+
+  if (dropdownToggle && dropdownMenu) {
+    dropdownToggle.addEventListener('click', () => {
+      const isOpen = dropdownMenu.classList.toggle('show');
+      dropdownToggle.setAttribute('aria-expanded', String(isOpen));
+      if (isOpen) {
+        dropdownMenu.querySelector('a')?.focus();
+      }
+    });
+
+    dropdownToggle.addEventListener('keydown', (event) => {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        dropdownMenu.classList.add('show');
+        dropdownToggle.setAttribute('aria-expanded', 'true');
+        dropdownMenu.querySelector('a')?.focus();
+      }
+    });
+
+    dropdownMenu.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closeDropdown();
+        dropdownToggle.focus();
+      }
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!dropdownMenu.contains(event.target) && !dropdownToggle.contains(event.target)) {
+        closeDropdown();
+      }
+    });
+  }
+
+  const forms = document.querySelectorAll('form[data-validate="true"]');
+
+  forms.forEach((form) => {
+    const message = form.querySelector('.form-message');
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      let firstInvalid = null;
+      const requiredFields = form.querySelectorAll('[required]');
+      requiredFields.forEach((field) => {
+        const input = field;
+        if (input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement) {
+          if (!input.checkValidity()) {
+            input.classList.add('input-error');
+            firstInvalid = firstInvalid || input;
+          } else {
+            input.classList.remove('input-error');
+          }
+        }
+      });
+
+      if (firstInvalid) {
+        if (message) {
+          message.textContent = 'Please review the highlighted fields and try again.';
+        }
+        firstInvalid.focus();
+        return;
+      }
+
+      if (message) {
+        const successText = form.getAttribute('data-success-message') || 'Thanks! Your submission has been received.';
+        message.textContent = successText;
+      }
+      form.reset();
+    });
+
+    form.addEventListener('input', (event) => {
+      const target = event.target;
+      if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+        if (target.checkValidity()) {
+          target.classList.remove('input-error');
+        }
+      }
+    });
+  });
+});

--- a/agentwebapplications.com/privacy.html
+++ b/agentwebapplications.com/privacy.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Privacy Policy | Agent Web Applications</title>
+  <meta name="description" content="Privacy policy for Agent Web Applications covering data collection, use, and protection practices.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+  <script defer src="js/script.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <div id="login" class="sr-only" aria-hidden="true">Client portal access for subscribers is handled through our secure workspace.</div>
+  <header class="site-header" role="banner">
+    <div class="container nav-wrapper">
+      <a class="logo" href="index.html" aria-label="Agent Web Applications home">
+        <svg aria-hidden="true" viewBox="0 0 48 48">
+          <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+          <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+          <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+        </svg>
+        <span>Agent Web Applications</span>
+      </a>
+      <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+      <nav class="primary-nav" id="primary-navigation" aria-label="Primary navigation">
+        <ul class="nav-list">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li class="nav-dropdown">
+            <button class="dropdown-toggle" type="button" data-dropdown-toggle aria-expanded="false" aria-haspopup="true">
+              Services
+              <svg aria-hidden="true" viewBox="0 0 16 16">
+                <path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+            <ul class="dropdown-menu" data-dropdown-menu>
+              <li><a href="services.html#tier-basic">Launch Pad (Basic)</a></li>
+              <li><a href="services.html#tier-pro">Workflow Studio (Pro)</a></li>
+              <li><a href="services.html#tier-enterprise">Co-Pilot Cloud (Enterprise)</a></li>
+            </ul>
+          </li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <div class="nav-actions">
+        <a class="btn btn-secondary" href="#login">Login</a>
+        <a class="btn btn-primary" href="demo.html">Request a Demo</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
+          <span aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img">
+              <path d="M12 4a1 1 0 0 1 1 1v2.06a1 1 0 0 1-2 0V5a1 1 0 0 1 1-1zm6.36 3.64a1 1 0 0 1 0 1.41l-1.46 1.46a1 1 0 0 1-1.41-1.41l1.46-1.46a1 1 0 0 1 1.41 0zM19 11h2a1 1 0 0 1 0 2h-2a1 1 0 0 1 0-2zm-7 7a1 1 0 0 1 1-1h2.06a1 1 0 0 1 0 2H13a1 1 0 0 1-1-1zm-5.95-1.05a1 1 0 0 1 1.41 0l1.46 1.46a1 1 0 0 1-1.41 1.41l-1.46-1.46a1 1 0 0 1 0-1.41zM5 11a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2h2zm1.05-5.95a1 1 0 0 1 1.41 0l1.46 1.46A1 1 0 0 1 7.51 7.92L6.05 6.46a1 1 0 0 1 0-1.41z" fill="currentColor"></path>
+              <circle cx="12" cy="12" r="3" fill="currentColor"></circle>
+            </svg>
+          </span>
+          <span data-theme-label>Switch to dark mode</span>
+        </button>
+      </div>
+    </div>
+  </header>
+  <main id="main" class="section">
+    <div class="container">
+      <article class="legal">
+        <h1>Privacy Policy</h1>
+        <p>Updated January 2025</p>
+        <p>Agent Web Applications (“AWA,” “we,” “our,” “us”) is committed to protecting your privacy. This policy explains how we collect, use, and protect information when you interact with our website, services, and products.</p>
+
+        <h2>Information we collect</h2>
+        <p>We collect information that you provide directly, such as contact details submitted via forms, demo requests, or support conversations. We also gather technical information automatically including IP address, device type, and pages visited using cookies and similar technologies. When we act as a processor for clients, we handle data strictly according to contractual obligations.</p>
+
+        <h2>How we use information</h2>
+        <p>AWA uses information to deliver services, respond to inquiries, improve product functionality, and maintain security. We may send service-related communications or marketing messages that you can opt out of at any time.</p>
+
+        <h2>How we share information</h2>
+        <p>We do not sell personal information. We share data only with trusted vendors that support our operations, such as cloud hosting and analytics providers, under confidentiality agreements. We may also disclose information to comply with legal obligations or to protect our rights.</p>
+
+        <h2>Data protection</h2>
+        <p>We employ administrative, technical, and physical safeguards to protect data. These include encryption in transit and at rest, access controls, continuous monitoring, and regular security reviews.</p>
+
+        <h2>Your choices</h2>
+        <p>You can request access, correction, or deletion of your personal information by emailing <a href="mailto:privacy@agentwebapplications.com">privacy@agentwebapplications.com</a>. If you receive marketing emails, you may unsubscribe via the link in each message.</p>
+
+        <h2>International transfers</h2>
+        <p>We may process data in countries where we operate. When transferring personal information internationally, we implement appropriate safeguards such as Standard Contractual Clauses.</p>
+
+        <h2>Contact us</h2>
+        <p>For questions about this policy or our privacy practices, contact: privacy@agentwebapplications.com.</p>
+      </article>
+    </div>
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-brand">
+          <a class="logo" href="index.html">
+            <svg aria-hidden="true" viewBox="0 0 48 48">
+              <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+              <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+              <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+            </svg>
+            <span>Agent Web Applications</span>
+          </a>
+          <p>We design, govern, and scale AI agent web apps for regulated teams that need measurable outcomes.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="btn btn-ghost">Netshow.AI</a>
+        </div>
+        <div>
+          <h3 class="sr-only">Quick Links</h3>
+          <div class="footer-links">
+            <a href="index.html">Home</a>
+            <a href="about.html">About</a>
+            <a href="services.html">Services</a>
+            <a href="blog.html">Blog</a>
+            <a href="faq.html">FAQ</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Legal Links</h3>
+          <div class="footer-links">
+            <a href="privacy.html" aria-current="page">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="disclosure.html">Disclosure</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Contact Information</h3>
+          <div class="footer-links">
+            <span>99 Market Street, Suite 540<br>San Francisco, CA 94105</span>
+            <a href="tel:+14155550123">+1 (415) 555-0123</a>
+            <a href="mailto:hello@agentwebapplications.com">hello@agentwebapplications.com</a>
+            <div class="social-links" aria-label="Social media">
+              <a href="https://www.facebook.com" aria-label="Facebook">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M14 8h2V5h-2c-2.2 0-4 1.8-4 4v2H8v3h2v7h3v-7h3l1-3h-4V9c0-.6.4-1 1-1z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.twitter.com" aria-label="X">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4 4l7.5 7.5L4 20h3.5l5.2-6 5.1 6H20l-7.4-8L20 4h-3.4l-4.7 5.5L7.2 4z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.instagram.com" aria-label="Instagram">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <rect x="3" y="3" width="18" height="18" rx="5" ry="5" fill="none" stroke="currentColor" stroke-width="2"></rect>
+                  <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="2"></circle>
+                  <circle cx="17" cy="7" r="1.5" fill="currentColor"></circle>
+                </svg>
+              </a>
+              <a href="https://www.linkedin.com" aria-label="LinkedIn">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4.98 3.5a2 2 0 1 1 0 4 2 2 0 0 1 0-4zM4 8.75h2.1V20H4zM9.25 8.75H11.3v1.54h.03c.29-.55 1-1.13 2.06-1.13 2.2 0 2.6 1.45 2.6 3.33V20h-2.1v-6c0-1.43-.03-3.26-1.99-3.26-1.99 0-2.3 1.55-2.3 3.15V20H9.25z" fill="currentColor"></path>
+                </svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© 2025 Agent Web Applications. All Rights Reserved.</span>
+        <span>Built for intelligent orchestration of web-based AI agents.</span>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/agentwebapplications.com/products.html
+++ b/agentwebapplications.com/products.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Products | Agent Web Applications Toolkits</title>
+  <meta name="description" content="Browse digital toolkits, template packs, and analytics guides from Agent Web Applications that accelerate compliant AI agent launches.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+  <script defer src="js/script.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <div id="login" class="sr-only" aria-hidden="true">Client portal access for subscribers is handled through our secure workspace.</div>
+  <header class="site-header" role="banner">
+    <div class="container nav-wrapper">
+      <a class="logo" href="index.html" aria-label="Agent Web Applications home">
+        <svg aria-hidden="true" viewBox="0 0 48 48">
+          <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+          <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+          <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+        </svg>
+        <span>Agent Web Applications</span>
+      </a>
+      <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+      <nav class="primary-nav" id="primary-navigation" aria-label="Primary navigation">
+        <ul class="nav-list">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li class="nav-dropdown">
+            <button class="dropdown-toggle" type="button" data-dropdown-toggle aria-expanded="false" aria-haspopup="true">
+              Services
+              <svg aria-hidden="true" viewBox="0 0 16 16">
+                <path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+            <ul class="dropdown-menu" data-dropdown-menu>
+              <li><a href="services.html#tier-basic">Launch Pad (Basic)</a></li>
+              <li><a href="services.html#tier-pro">Workflow Studio (Pro)</a></li>
+              <li><a href="services.html#tier-enterprise">Co-Pilot Cloud (Enterprise)</a></li>
+            </ul>
+          </li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <div class="nav-actions">
+        <a class="btn btn-secondary" href="#login">Login</a>
+        <a class="btn btn-primary" href="demo.html">Request a Demo</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
+          <span aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img">
+              <path d="M12 4a1 1 0 0 1 1 1v2.06a1 1 0 0 1-2 0V5a1 1 0 0 1 1-1zm6.36 3.64a1 1 0 0 1 0 1.41l-1.46 1.46a1 1 0 0 1-1.41-1.41l1.46-1.46a1 1 0 0 1 1.41 0zM19 11h2a1 1 0 0 1 0 2h-2a1 1 0 0 1 0-2zm-7 7a1 1 0 0 1 1-1h2.06a1 1 0 0 1 0 2H13a1 1 0 0 1-1-1zm-5.95-1.05a1 1 0 0 1 1.41 0l1.46 1.46a1 1 0 0 1-1.41 1.41l-1.46-1.46a1 1 0 0 1 0-1.41zM5 11a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2h2zm1.05-5.95a1 1 0 0 1 1.41 0l1.46 1.46A1 1 0 0 1 7.51 7.92L6.05 6.46a1 1 0 0 1 0-1.41z" fill="currentColor"></path>
+              <circle cx="12" cy="12" r="3" fill="currentColor"></circle>
+            </svg>
+          </span>
+          <span data-theme-label>Switch to dark mode</span>
+        </button>
+      </div>
+    </div>
+  </header>
+  <main id="main">
+    <section class="section">
+      <div class="container">
+        <div class="section-header">
+          <h1>Digital products that accelerate your launch</h1>
+          <p>Our toolkits pack the frameworks, templates, and analytics guides we use on client engagements so your teams can move faster between planning sessions.</p>
+        </div>
+        <div class="product-grid">
+          <article class="product-card">
+            <img src="images/product-kit.svg" alt="Illustration representing the agent readiness playbook">
+            <div class="product-body">
+              <h3>Agent Readiness Playbook</h3>
+              <p>A 120-page guide detailing governance questionnaires, risk registers, and workshop exercises for regulated AI projects.</p>
+              <p><strong>$249</strong> • Includes lifetime updates</p>
+              <a class="btn btn-secondary" href="contact.html">Request license</a>
+            </div>
+          </article>
+          <article class="product-card">
+            <img src="images/product-templates.svg" alt="Illustration representing interface templates">
+            <div class="product-body">
+              <h3>Interface Template Pack</h3>
+              <p>Responsive HTML components for common agent screens like escalation prompts, policy reminders, and audit modals.</p>
+              <p><strong>$399</strong> • Includes usage rights for 5 projects</p>
+              <a class="btn btn-secondary" href="contact.html">Download details</a>
+            </div>
+          </article>
+          <article class="product-card">
+            <img src="images/product-insights.svg" alt="Illustration representing analytics dashboards">
+            <div class="product-body">
+              <h3>Observability Dashboard Kit</h3>
+              <p>Pre-built chart templates and SQL snippets to monitor agent accuracy, resolution times, and compliance notes across teams.</p>
+              <p><strong>$329</strong> • Delivered as Looker &amp; Power BI assets</p>
+              <a class="btn btn-secondary" href="contact.html">See sample visuals</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container final-cta">
+        <h2>Pair products with our service teams</h2>
+        <p>All digital products include a live implementation clinic hosted by our specialists so you can put every asset to work immediately.</p>
+        <div class="nav-actions" style="justify-content:center; gap:1rem; flex-wrap:wrap;">
+          <a class="btn btn-primary" href="services.html">View service packages</a>
+          <a class="btn btn-ghost" href="demo.html">Watch the guided demo</a>
+        </div>
+      </div>
+    </section>
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-brand">
+          <a class="logo" href="index.html">
+            <svg aria-hidden="true" viewBox="0 0 48 48">
+              <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+              <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+              <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+            </svg>
+            <span>Agent Web Applications</span>
+          </a>
+          <p>We design, govern, and scale AI agent web apps for regulated teams that need measurable outcomes.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="btn btn-ghost">Netshow.AI</a>
+        </div>
+        <div>
+          <h3 class="sr-only">Quick Links</h3>
+          <div class="footer-links">
+            <a href="index.html">Home</a>
+            <a href="about.html">About</a>
+            <a href="services.html">Services</a>
+            <a href="blog.html">Blog</a>
+            <a href="faq.html">FAQ</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Legal Links</h3>
+          <div class="footer-links">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="disclosure.html">Disclosure</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Contact Information</h3>
+          <div class="footer-links">
+            <span>99 Market Street, Suite 540<br>San Francisco, CA 94105</span>
+            <a href="tel:+14155550123">+1 (415) 555-0123</a>
+            <a href="mailto:hello@agentwebapplications.com">hello@agentwebapplications.com</a>
+            <div class="social-links" aria-label="Social media">
+              <a href="https://www.facebook.com" aria-label="Facebook">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M14 8h2V5h-2c-2.2 0-4 1.8-4 4v2H8v3h2v7h3v-7h3l1-3h-4V9c0-.6.4-1 1-1z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.twitter.com" aria-label="X">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4 4l7.5 7.5L4 20h3.5l5.2-6 5.1 6H20l-7.4-8L20 4h-3.4l-4.7 5.5L7.2 4z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.instagram.com" aria-label="Instagram">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <rect x="3" y="3" width="18" height="18" rx="5" ry="5" fill="none" stroke="currentColor" stroke-width="2"></rect>
+                  <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="2"></circle>
+                  <circle cx="17" cy="7" r="1.5" fill="currentColor"></circle>
+                </svg>
+              </a>
+              <a href="https://www.linkedin.com" aria-label="LinkedIn">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4.98 3.5a2 2 0 1 1 0 4 2 2 0 0 1 0-4zM4 8.75h2.1V20H4zM9.25 8.75H11.3v1.54h.03c.29-.55 1-1.13 2.06-1.13 2.2 0 2.6 1.45 2.6 3.33V20h-2.1v-6c0-1.43-.03-3.26-1.99-3.26-1.99 0-2.3 1.55-2.3 3.15V20H9.25z" fill="currentColor"></path>
+                </svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© 2025 Agent Web Applications. All Rights Reserved.</span>
+        <span>Built for intelligent orchestration of web-based AI agents.</span>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/agentwebapplications.com/reviews.html
+++ b/agentwebapplications.com/reviews.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Customer Reviews &amp; Case Studies | Agent Web Applications</title>
+  <meta name="description" content="Read detailed customer reviews and case studies showcasing Agent Web Applications deployments.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+  <script defer src="js/script.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <div id="login" class="sr-only" aria-hidden="true">Client portal access for subscribers is handled through our secure workspace.</div>
+  <header class="site-header" role="banner">
+    <div class="container nav-wrapper">
+      <a class="logo" href="index.html" aria-label="Agent Web Applications home">
+        <svg aria-hidden="true" viewBox="0 0 48 48">
+          <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+          <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+          <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+        </svg>
+        <span>Agent Web Applications</span>
+      </a>
+      <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+      <nav class="primary-nav" id="primary-navigation" aria-label="Primary navigation">
+        <ul class="nav-list">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li class="nav-dropdown">
+            <button class="dropdown-toggle" type="button" data-dropdown-toggle aria-expanded="false" aria-haspopup="true">
+              Services
+              <svg aria-hidden="true" viewBox="0 0 16 16">
+                <path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+            <ul class="dropdown-menu" data-dropdown-menu>
+              <li><a href="services.html#tier-basic">Launch Pad (Basic)</a></li>
+              <li><a href="services.html#tier-pro">Workflow Studio (Pro)</a></li>
+              <li><a href="services.html#tier-enterprise">Co-Pilot Cloud (Enterprise)</a></li>
+            </ul>
+          </li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <div class="nav-actions">
+        <a class="btn btn-secondary" href="#login">Login</a>
+        <a class="btn btn-primary" href="demo.html">Request a Demo</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
+          <span aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img">
+              <path d="M12 4a1 1 0 0 1 1 1v2.06a1 1 0 0 1-2 0V5a1 1 0 0 1 1-1zm6.36 3.64a1 1 0 0 1 0 1.41l-1.46 1.46a1 1 0 0 1-1.41-1.41l1.46-1.46a1 1 0 0 1 1.41 0zM19 11h2a1 1 0 0 1 0 2h-2a1 1 0 0 1 0-2zm-7 7a1 1 0 0 1 1-1h2.06a1 1 0 0 1 0 2H13a1 1 0 0 1-1-1zm-5.95-1.05a1 1 0 0 1 1.41 0l1.46 1.46a1 1 0 0 1-1.41 1.41l-1.46-1.46a1 1 0 0 1 0-1.41zM5 11a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2h2zm1.05-5.95a1 1 0 0 1 1.41 0l1.46 1.46A1 1 0 0 1 7.51 7.92L6.05 6.46a1 1 0 0 1 0-1.41z" fill="currentColor"></path>
+              <circle cx="12" cy="12" r="3" fill="currentColor"></circle>
+            </svg>
+          </span>
+          <span data-theme-label>Switch to dark mode</span>
+        </button>
+      </div>
+    </div>
+  </header>
+  <main id="main" class="section">
+    <div class="container">
+      <div class="section-header">
+        <h1>Customer success stories</h1>
+        <p>Learn how regulated organizations roll out agent web apps with confidence using our orchestration, governance, and observability approach.</p>
+      </div>
+      <div class="review-grid">
+        <article class="review-card">
+          <h2>Horizon Clinics — Nursing intake copilots</h2>
+          <p>“We partnered with Agent Web Applications to replace clipboards and spreadsheets with an agent-guided intake flow. Within two months nurses moved from manual documentation to guided prompts that capture vitals, consent, and insurance data in real time.”</p>
+          <p>Results:</p>
+          <ul>
+            <li>31% reduction in patient wait times.</li>
+            <li>Automated compliance logging with zero audit findings.</li>
+            <li>Nurse satisfaction jumped from 3.1 to 4.6 out of 5.</li>
+          </ul>
+        </article>
+        <article class="review-card">
+          <h2>Orbit Freight — Dispatch operations</h2>
+          <p>“Our dispatchers juggle customs rules, carrier capacity, and weather alerts. The agent web app built by the AWA team gave them a single pane of glass with policy-aware recommendations and escalation buttons. We finally have confidence in the decisions agents make.”</p>
+          <p>Results:</p>
+          <ul>
+            <li>Average resolution time fell from 18 minutes to 9 minutes.</li>
+            <li>Exception rate down 42% thanks to automated compliance hints.</li>
+            <li>Live telemetry dashboard adopted by 6 global control towers.</li>
+          </ul>
+        </article>
+        <article class="review-card">
+          <h2>NorthBridge Energy — Field compliance companion</h2>
+          <p>“AWA helped us digitize field inspection checklists into an agent companion that works offline and syncs when crews return to base. Human reviewers now approve high-risk findings in minutes rather than days.”</p>
+          <p>Results:</p>
+          <ul>
+            <li>Audit preparation time reduced by 65%.</li>
+            <li>Inspection backlog cleared within three weeks.</li>
+            <li>Real-time map shows compliance status across 128 facilities.</li>
+          </ul>
+        </article>
+      </div>
+    </div>
+
+    <section class="section" style="padding-top:0;">
+      <div class="container case-study">
+        <div>
+          <img src="images/case-study-1.svg" alt="DataLift case study logo">
+          <h2>Case study: DataLift Analytics</h2>
+          <p>DataLift wanted to launch a governed analytics assistant for their clients in the pharmaceutical sector. We integrated their proprietary dataset, built dosage validation workflows, and embedded guardrails to flag off-label recommendations.</p>
+          <ul>
+            <li>Deployment model: Hybrid (DataLift VPC + AWA managed services)</li>
+            <li>Time to launch: 7 weeks</li>
+            <li>Impact: 3x increase in analyst throughput, 100% audit pass rate</li>
+          </ul>
+        </div>
+        <div>
+          <img src="images/case-study-2.svg" alt="ClinicX case study logo">
+          <h2>Case study: ClinicX Collaborative</h2>
+          <p>ClinicX needed a multi-location care coordination assistant with HIPAA-compliant messaging. AWA delivered agent workflows that synchronize patient status, insurance verification, and aftercare scheduling with human oversight at every step.</p>
+          <ul>
+            <li>Deployment model: Fully managed cloud</li>
+            <li>Time to launch: 5 weeks</li>
+            <li>Impact: 25% improvement in discharge accuracy, 92% staff adoption</li>
+          </ul>
+        </div>
+        <div>
+          <img src="images/case-study-3.svg" alt="OrbitOps case study logo">
+          <h2>Case study: OrbitOps Aerospace</h2>
+          <p>OrbitOps needed to merge engineering logs, regulations, and supplier updates into a single agent workspace. We created a flight-readiness cockpit with real-time risk scoring, human escalation, and digital sign-off tracking.</p>
+          <ul>
+            <li>Deployment model: On-premise (GovCloud)</li>
+            <li>Time to launch: 9 weeks</li>
+            <li>Impact: 18% faster launch readiness reviews, 0 policy breaches</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container final-cta">
+        <h2>Ready to write your success story?</h2>
+        <p>We’ll tailor an agent orchestration plan, deliver the guardrails regulators expect, and equip your team with the dashboards to keep performance on track.</p>
+        <div class="nav-actions" style="justify-content:center; gap:1rem; flex-wrap:wrap;">
+          <a class="btn btn-primary" href="services.html">View services</a>
+          <a class="btn btn-ghost" href="demo.html">Book a guided demo</a>
+        </div>
+      </div>
+    </section>
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-brand">
+          <a class="logo" href="index.html">
+            <svg aria-hidden="true" viewBox="0 0 48 48">
+              <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+              <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+              <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+            </svg>
+            <span>Agent Web Applications</span>
+          </a>
+          <p>We design, govern, and scale AI agent web apps for regulated teams that need measurable outcomes.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="btn btn-ghost">Netshow.AI</a>
+        </div>
+        <div>
+          <h3 class="sr-only">Quick Links</h3>
+          <div class="footer-links">
+            <a href="index.html">Home</a>
+            <a href="about.html">About</a>
+            <a href="services.html">Services</a>
+            <a href="blog.html">Blog</a>
+            <a href="faq.html">FAQ</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Legal Links</h3>
+          <div class="footer-links">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="disclosure.html">Disclosure</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Contact Information</h3>
+          <div class="footer-links">
+            <span>99 Market Street, Suite 540<br>San Francisco, CA 94105</span>
+            <a href="tel:+14155550123">+1 (415) 555-0123</a>
+            <a href="mailto:hello@agentwebapplications.com">hello@agentwebapplications.com</a>
+            <div class="social-links" aria-label="Social media">
+              <a href="https://www.facebook.com" aria-label="Facebook">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M14 8h2V5h-2c-2.2 0-4 1.8-4 4v2H8v3h2v7h3v-7h3l1-3h-4V9c0-.6.4-1 1-1z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.twitter.com" aria-label="X">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4 4l7.5 7.5L4 20h3.5l5.2-6 5.1 6H20l-7.4-8L20 4h-3.4l-4.7 5.5L7.2 4z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.instagram.com" aria-label="Instagram">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <rect x="3" y="3" width="18" height="18" rx="5" ry="5" fill="none" stroke="currentColor" stroke-width="2"></rect>
+                  <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="2"></circle>
+                  <circle cx="17" cy="7" r="1.5" fill="currentColor"></circle>
+                </svg>
+              </a>
+              <a href="https://www.linkedin.com" aria-label="LinkedIn">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4.98 3.5a2 2 0 1 1 0 4 2 2 0 0 1 0-4zM4 8.75h2.1V20H4zM9.25 8.75H11.3v1.54h.03c.29-.55 1-1.13 2.06-1.13 2.2 0 2.6 1.45 2.6 3.33V20h-2.1v-6c0-1.43-.03-3.26-1.99-3.26-1.99 0-2.3 1.55-2.3 3.15V20H9.25z" fill="currentColor"></path>
+                </svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© 2025 Agent Web Applications. All Rights Reserved.</span>
+        <span>Built for intelligent orchestration of web-based AI agents.</span>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/agentwebapplications.com/services.html
+++ b/agentwebapplications.com/services.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Services | Agent Web Applications Subscription Plans</title>
+  <meta name="description" content="Review Agent Web Applications subscription tiers, pricing, and included features for launching compliant AI agent web applications.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+  <script defer src="js/script.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <div id="login" class="sr-only" aria-hidden="true">Client portal access for subscribers is handled through our secure workspace.</div>
+  <header class="site-header" role="banner">
+    <div class="container nav-wrapper">
+      <a class="logo" href="index.html" aria-label="Agent Web Applications home">
+        <svg aria-hidden="true" viewBox="0 0 48 48">
+          <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+          <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+          <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+        </svg>
+        <span>Agent Web Applications</span>
+      </a>
+      <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+      <nav class="primary-nav" id="primary-navigation" aria-label="Primary navigation">
+        <ul class="nav-list">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li class="nav-dropdown">
+            <button class="dropdown-toggle" type="button" data-dropdown-toggle aria-expanded="false" aria-haspopup="true">
+              Services
+              <svg aria-hidden="true" viewBox="0 0 16 16">
+                <path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+            <ul class="dropdown-menu" data-dropdown-menu>
+              <li><a href="#tier-basic">Launch Pad (Basic)</a></li>
+              <li><a href="#tier-pro">Workflow Studio (Pro)</a></li>
+              <li><a href="#tier-enterprise">Co-Pilot Cloud (Enterprise)</a></li>
+            </ul>
+          </li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <div class="nav-actions">
+        <a class="btn btn-secondary" href="#login">Login</a>
+        <a class="btn btn-primary" href="demo.html">Request a Demo</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
+          <span aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img">
+              <path d="M12 4a1 1 0 0 1 1 1v2.06a1 1 0 0 1-2 0V5a1 1 0 0 1 1-1zm6.36 3.64a1 1 0 0 1 0 1.41l-1.46 1.46a1 1 0 0 1-1.41-1.41l1.46-1.46a1 1 0 0 1 1.41 0zM19 11h2a1 1 0 0 1 0 2h-2a1 1 0 0 1 0-2zm-7 7a1 1 0 0 1 1-1h2.06a1 1 0 0 1 0 2H13a1 1 0 0 1-1-1zm-5.95-1.05a1 1 0 0 1 1.41 0l1.46 1.46a1 1 0 0 1-1.41 1.41l-1.46-1.46a1 1 0 0 1 0-1.41zM5 11a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2h2zm1.05-5.95a1 1 0 0 1 1.41 0l1.46 1.46A1 1 0 0 1 7.51 7.92L6.05 6.46a1 1 0 0 1 0-1.41z" fill="currentColor"></path>
+              <circle cx="12" cy="12" r="3" fill="currentColor"></circle>
+            </svg>
+          </span>
+          <span data-theme-label>Switch to dark mode</span>
+        </button>
+      </div>
+    </div>
+  </header>
+  <main id="main">
+    <section class="section">
+      <div class="container">
+        <div class="section-header">
+          <h1>Choose the right launch path</h1>
+          <p>Every subscription includes governance workshops, agent blueprinting, and secure hosting. Pick the tier that matches your compliance needs and release cadence.</p>
+        </div>
+        <div class="plan-grid">
+          <article class="plan-card" id="tier-basic">
+            <h3>Launch Pad</h3>
+            <p class="price">$3,200<span style="font-size:1rem; font-weight:500;"> / month</span></p>
+            <p>Perfect for teams validating their first agent workflow with up to two departments.</p>
+            <ul>
+              <li>Policy-first design sprint (2 weeks)</li>
+              <li>Single agent web app with branded UI</li>
+              <li>Knowledge base ingestion up to 250 documents</li>
+              <li>Baseline compliance review &amp; documentation bundle</li>
+              <li>Email-based operator support</li>
+            </ul>
+            <a class="btn btn-secondary" href="contact.html">Talk to sales</a>
+          </article>
+          <article class="plan-card" id="tier-pro" style="border:2px solid var(--color-primary); box-shadow:var(--shadow-lg);">
+            <h3>Workflow Studio</h3>
+            <p class="price">$6,800<span style="font-size:1rem; font-weight:500;"> / month</span></p>
+            <p>Scale AI agents across multiple journeys with deep integrations and human-in-the-loop oversight.</p>
+            <ul>
+              <li>Up to three concurrent agent web apps</li>
+              <li>Real-time analytics &amp; redaction dashboards</li>
+              <li>Identity-aware routing and approval workflows</li>
+              <li>Dedicated compliance architect and quarterly audits</li>
+              <li>Slack + email support with four-hour SLA</li>
+            </ul>
+            <a class="btn btn-primary" href="demo.html">Book a demo</a>
+          </article>
+          <article class="plan-card" id="tier-enterprise">
+            <h3>Co-Pilot Cloud</h3>
+            <p class="price">Custom pricing</p>
+            <p>For global enterprises requiring hybrid deployments, custom guardrails, and 24/7 operations coverage.</p>
+            <ul>
+              <li>Unlimited agent web apps &amp; personas</li>
+              <li>VPC or on-premise deployment with managed updates</li>
+              <li>Advanced testing sandbox and shadow-mode rollouts</li>
+              <li>24/7 support, dedicated success squad, on-site workshops</li>
+              <li>Regulator reporting packs for HIPAA, FAA, and ISO 27001</li>
+            </ul>
+            <a class="btn btn-secondary" href="contact.html">Schedule an assessment</a>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="comparison-heading">
+      <div class="container">
+        <div class="section-header" style="margin-bottom:1.5rem;">
+          <h2 id="comparison-heading">Compare plan capabilities</h2>
+          <p>We designed clear, transparent tiers so you know exactly how every feature scales with your team.</p>
+        </div>
+        <div class="table-scroll">
+          <table class="comparison-table">
+            <thead>
+              <tr>
+                <th scope="col">Feature</th>
+                <th scope="col">Launch Pad</th>
+                <th scope="col">Workflow Studio</th>
+                <th scope="col">Co-Pilot Cloud</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">Agent web apps included</th>
+                <td>1</td>
+                <td>3</td>
+                <td>Unlimited</td>
+              </tr>
+              <tr>
+                <th scope="row">Knowledge connectors</th>
+                <td>SharePoint, Google Drive</td>
+                <td>+ Salesforce, Epic, ServiceNow</td>
+                <td>Custom connectors &amp; data lake adapters</td>
+              </tr>
+              <tr>
+                <th scope="row">Human approval workflow</th>
+                <td>Single reviewer lane</td>
+                <td>Multi-role approval with escalation</td>
+                <td>Configurable across business units</td>
+              </tr>
+              <tr>
+                <th scope="row">Observability suite</th>
+                <td>Weekly analytics digest</td>
+                <td>Live dashboards &amp; anomaly alerts</td>
+                <td>Custom metrics API + SIEM integration</td>
+              </tr>
+              <tr>
+                <th scope="row">Security posture</th>
+                <td>SOC 2 Type I attestation</td>
+                <td>SOC 2 Type II + HIPAA BAA</td>
+                <td>Industry-specific compliance packs</td>
+              </tr>
+              <tr>
+                <th scope="row">Support response</th>
+                <td>Next business day</td>
+                <td>Within 4 hours (business days)</td>
+                <td>24/7 priority hotline</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container final-cta">
+        <h2>Need help selecting the right tier?</h2>
+        <p>Our strategists will review your workflows, data residency requirements, and adoption goals to recommend the best path forward.</p>
+        <div class="nav-actions" style="justify-content:center; gap:1rem; flex-wrap:wrap;">
+          <a class="btn btn-primary" href="demo.html">Explore the interactive demo</a>
+          <a class="btn btn-ghost" href="contact.html">Contact our team</a>
+        </div>
+      </div>
+    </section>
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-brand">
+          <a class="logo" href="index.html">
+            <svg aria-hidden="true" viewBox="0 0 48 48">
+              <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+              <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+              <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+            </svg>
+            <span>Agent Web Applications</span>
+          </a>
+          <p>We design, govern, and scale AI agent web apps for regulated teams that need measurable outcomes.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="btn btn-ghost">Netshow.AI</a>
+        </div>
+        <div>
+          <h3 class="sr-only">Quick Links</h3>
+          <div class="footer-links">
+            <a href="index.html">Home</a>
+            <a href="about.html">About</a>
+            <a href="services.html" aria-current="page">Services</a>
+            <a href="blog.html">Blog</a>
+            <a href="faq.html">FAQ</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Legal Links</h3>
+          <div class="footer-links">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="disclosure.html">Disclosure</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Contact Information</h3>
+          <div class="footer-links">
+            <span>99 Market Street, Suite 540<br>San Francisco, CA 94105</span>
+            <a href="tel:+14155550123">+1 (415) 555-0123</a>
+            <a href="mailto:hello@agentwebapplications.com">hello@agentwebapplications.com</a>
+            <div class="social-links" aria-label="Social media">
+              <a href="https://www.facebook.com" aria-label="Facebook">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M14 8h2V5h-2c-2.2 0-4 1.8-4 4v2H8v3h2v7h3v-7h3l1-3h-4V9c0-.6.4-1 1-1z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.twitter.com" aria-label="X">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4 4l7.5 7.5L4 20h3.5l5.2-6 5.1 6H20l-7.4-8L20 4h-3.4l-4.7 5.5L7.2 4z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.instagram.com" aria-label="Instagram">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <rect x="3" y="3" width="18" height="18" rx="5" ry="5" fill="none" stroke="currentColor" stroke-width="2"></rect>
+                  <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="2"></circle>
+                  <circle cx="17" cy="7" r="1.5" fill="currentColor"></circle>
+                </svg>
+              </a>
+              <a href="https://www.linkedin.com" aria-label="LinkedIn">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4.98 3.5a2 2 0 1 1 0 4 2 2 0 0 1 0-4zM4 8.75h2.1V20H4zM9.25 8.75H11.3v1.54h.03c.29-.55 1-1.13 2.06-1.13 2.2 0 2.6 1.45 2.6 3.33V20h-2.1v-6c0-1.43-.03-3.26-1.99-3.26-1.99 0-2.3 1.55-2.3 3.15V20H9.25z" fill="currentColor"></path>
+                </svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© 2025 Agent Web Applications. All Rights Reserved.</span>
+        <span>Built for intelligent orchestration of web-based AI agents.</span>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/agentwebapplications.com/terms.html
+++ b/agentwebapplications.com/terms.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Terms of Service | Agent Web Applications</title>
+  <meta name="description" content="Terms of service for Agent Web Applications covering use of the website and subscription offerings.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600;700&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/style.css">
+  <script defer src="js/script.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <div id="login" class="sr-only" aria-hidden="true">Client portal access for subscribers is handled through our secure workspace.</div>
+  <header class="site-header" role="banner">
+    <div class="container nav-wrapper">
+      <a class="logo" href="index.html" aria-label="Agent Web Applications home">
+        <svg aria-hidden="true" viewBox="0 0 48 48">
+          <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+          <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+          <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+        </svg>
+        <span>Agent Web Applications</span>
+      </a>
+      <button class="menu-toggle" type="button" data-menu-toggle aria-expanded="false" aria-controls="primary-navigation">Menu</button>
+      <nav class="primary-nav" id="primary-navigation" aria-label="Primary navigation">
+        <ul class="nav-list">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li class="nav-dropdown">
+            <button class="dropdown-toggle" type="button" data-dropdown-toggle aria-expanded="false" aria-haspopup="true">
+              Services
+              <svg aria-hidden="true" viewBox="0 0 16 16">
+                <path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+              </svg>
+            </button>
+            <ul class="dropdown-menu" data-dropdown-menu>
+              <li><a href="services.html#tier-basic">Launch Pad (Basic)</a></li>
+              <li><a href="services.html#tier-pro">Workflow Studio (Pro)</a></li>
+              <li><a href="services.html#tier-enterprise">Co-Pilot Cloud (Enterprise)</a></li>
+            </ul>
+          </li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+      <div class="nav-actions">
+        <a class="btn btn-secondary" href="#login">Login</a>
+        <a class="btn btn-primary" href="demo.html">Request a Demo</a>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
+          <span aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="img">
+              <path d="M12 4a1 1 0 0 1 1 1v2.06a1 1 0 0 1-2 0V5a1 1 0 0 1 1-1zm6.36 3.64a1 1 0 0 1 0 1.41l-1.46 1.46a1 1 0 0 1-1.41-1.41l1.46-1.46a1 1 0 0 1 1.41 0zM19 11h2a1 1 0 0 1 0 2h-2a1 1 0 0 1 0-2zm-7 7a1 1 0 0 1 1-1h2.06a1 1 0 0 1 0 2H13a1 1 0 0 1-1-1zm-5.95-1.05a1 1 0 0 1 1.41 0l1.46 1.46a1 1 0 0 1-1.41 1.41l-1.46-1.46a1 1 0 0 1 0-1.41zM5 11a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2h2zm1.05-5.95a1 1 0 0 1 1.41 0l1.46 1.46A1 1 0 0 1 7.51 7.92L6.05 6.46a1 1 0 0 1 0-1.41z" fill="currentColor"></path>
+              <circle cx="12" cy="12" r="3" fill="currentColor"></circle>
+            </svg>
+          </span>
+          <span data-theme-label>Switch to dark mode</span>
+        </button>
+      </div>
+    </div>
+  </header>
+  <main id="main" class="section">
+    <div class="container">
+      <article class="legal">
+        <h1>Terms of Service</h1>
+        <p>Updated January 2025</p>
+        <p>These Terms of Service (“Terms”) govern your use of agentwebapplications.com and any services we provide. By accessing or using our site or services, you agree to these Terms.</p>
+
+        <h2>Using our services</h2>
+        <p>You may use our website for lawful purposes. Subscription services are governed by the applicable Master Services Agreement or Order Form. You are responsible for ensuring that information you provide to us is accurate.</p>
+
+        <h2>Intellectual property</h2>
+        <p>Agent Web Applications retains all intellectual property rights to our technology, designs, and materials. Clients receive a license to use deliverables as defined in their agreements.</p>
+
+        <h2>Acceptable use</h2>
+        <p>You agree not to misuse our services or interfere with others. Prohibited conduct includes attempting to access our systems without authorization, uploading malicious code, or using deliverables for unlawful purposes.</p>
+
+        <h2>Confidentiality</h2>
+        <p>Both parties agree to protect confidential information shared during an engagement. We will only use client data to provide services and as permitted by contract.</p>
+
+        <h2>Disclaimers</h2>
+        <p>Our website is provided “as is” without warranties. Subscription deliverables are covered by warranties stated in the Master Services Agreement. We are not liable for indirect or consequential damages arising from use of our website.</p>
+
+        <h2>Termination</h2>
+        <p>We may suspend or terminate access to our site for any violation of these Terms. Clients may terminate subscriptions according to the provisions in their agreements.</p>
+
+        <h2>Updates to these Terms</h2>
+        <p>We may update these Terms periodically. We will post the revised policy with an updated date, and continued use constitutes acceptance.</p>
+
+        <h2>Contact</h2>
+        <p>Questions about these Terms can be sent to legal@agentwebapplications.com.</p>
+      </article>
+    </div>
+  </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="footer-inner">
+      <div class="footer-top">
+        <div class="footer-brand">
+          <a class="logo" href="index.html">
+            <svg aria-hidden="true" viewBox="0 0 48 48">
+              <rect width="48" height="48" rx="12" fill="var(--color-primary)" opacity="0.9"></rect>
+              <path d="M12 32L24 10l12 22" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"></path>
+              <circle cx="24" cy="32" r="6" fill="#f87b56"></circle>
+            </svg>
+            <span>Agent Web Applications</span>
+          </a>
+          <p>We design, govern, and scale AI agent web apps for regulated teams that need measurable outcomes.</p>
+          <a href="https://app.netshow.pro" target="_blank" rel="noopener" class="btn btn-ghost">Netshow.AI</a>
+        </div>
+        <div>
+          <h3 class="sr-only">Quick Links</h3>
+          <div class="footer-links">
+            <a href="index.html">Home</a>
+            <a href="about.html">About</a>
+            <a href="services.html">Services</a>
+            <a href="blog.html">Blog</a>
+            <a href="faq.html">FAQ</a>
+            <a href="contact.html">Contact</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Legal Links</h3>
+          <div class="footer-links">
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html" aria-current="page">Terms</a>
+            <a href="disclosure.html">Disclosure</a>
+          </div>
+        </div>
+        <div>
+          <h3 class="sr-only">Contact Information</h3>
+          <div class="footer-links">
+            <span>99 Market Street, Suite 540<br>San Francisco, CA 94105</span>
+            <a href="tel:+14155550123">+1 (415) 555-0123</a>
+            <a href="mailto:hello@agentwebapplications.com">hello@agentwebapplications.com</a>
+            <div class="social-links" aria-label="Social media">
+              <a href="https://www.facebook.com" aria-label="Facebook">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M14 8h2V5h-2c-2.2 0-4 1.8-4 4v2H8v3h2v7h3v-7h3l1-3h-4V9c0-.6.4-1 1-1z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.twitter.com" aria-label="X">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4 4l7.5 7.5L4 20h3.5l5.2-6 5.1 6H20l-7.4-8L20 4h-3.4l-4.7 5.5L7.2 4z" fill="currentColor"></path>
+                </svg>
+              </a>
+              <a href="https://www.instagram.com" aria-label="Instagram">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <rect x="3" y="3" width="18" height="18" rx="5" ry="5" fill="none" stroke="currentColor" stroke-width="2"></rect>
+                  <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="2"></circle>
+                  <circle cx="17" cy="7" r="1.5" fill="currentColor"></circle>
+                </svg>
+              </a>
+              <a href="https://www.linkedin.com" aria-label="LinkedIn">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M4.98 3.5a2 2 0 1 1 0 4 2 2 0 0 1 0-4zM4 8.75h2.1V20H4zM9.25 8.75H11.3v1.54h.03c.29-.55 1-1.13 2.06-1.13 2.2 0 2.6 1.45 2.6 3.33V20h-2.1v-6c0-1.43-.03-3.26-1.99-3.26-1.99 0-2.3 1.55-2.3 3.15V20H9.25z" fill="currentColor"></path>
+                </svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© 2025 Agent Web Applications. All Rights Reserved.</span>
+        <span>Built for intelligent orchestration of web-based AI agents.</span>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build new Agent Web Applications static site with multi-page marketing copy, products, demo, reviews, FAQ, blog, and legal content
- add custom design system with light/dark theming, responsive layouts, accessible navigation, and inline SVG illustrations
- implement shared JavaScript for theme persistence, mobile navigation, dropdown access, and client-side form validation across pages

## Reference
- https://agendidea.com

## Testing
- Opened index.html, navigated to all pages, toggled theme, verified responsive layout in Chrome DevTools (mobile and desktop breakpoints)
- Submitted form validations to confirm error and success states display correctly

## Checklist
- [x] No frameworks/build tools used
- [x] Unique palette + dark mode implemented
- [x] Unique copy vs. other domains and agentide-website
- [x] Inline/local SVG icons only
- [x] All pages load and are responsive

------
https://chatgpt.com/codex/tasks/task_b_68d3cbb3b5d8832aaed21c8b43b59e3b